### PR TITLE
Combine overlay fade logic

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -275,6 +275,35 @@ document.addEventListener("DOMContentLoaded", () => {
     initParallaxHero();
 
     window.addEventListener("hashchange", setActiveLink);
+
+    const overlay = document.querySelector(".page-transition-overlay");
+    if (overlay) {
+        const links = document.querySelectorAll("a[href]");
+        links.forEach(link => {
+            const href = link.getAttribute("href");
+            if (
+                !href ||
+                href.startsWith("http") ||
+                href.startsWith("mailto:") ||
+                href.startsWith("#") ||
+                href.endsWith(".pdf")
+            ) return;
+
+            link.addEventListener("click", (e) => {
+                e.preventDefault();
+
+                // Trigger fade with requestAnimationFrame
+                requestAnimationFrame(() => {
+                    overlay.classList.add("is-fading-in");
+
+                    // Delay nav just enough to let transition visibly begin
+                    setTimeout(() => {
+                        window.location.href = href;
+                    }, 500); // Match CSS transition duration
+                });
+            });
+        });
+    }
 });
 
 
@@ -311,41 +340,6 @@ function initProjectFilters() {
     });
   });
 }
-
-
-document.addEventListener("DOMContentLoaded", () => {
-  const overlay = document.querySelector(".page-transition-overlay");
-
-  if (!overlay) return;
-
-  const links = document.querySelectorAll("a[href]");
-
-  links.forEach(link => {
-    const href = link.getAttribute("href");
-
-    if (
-      !href ||
-      href.startsWith("http") ||
-      href.startsWith("mailto:") ||
-      href.startsWith("#") ||
-      href.endsWith(".pdf")
-    ) return;
-
-    link.addEventListener("click", (e) => {
-      e.preventDefault();
-
-      // Trigger fade with requestAnimationFrame
-      requestAnimationFrame(() => {
-        overlay.classList.add("is-fading-in");
-
-        // Delay nav just enough to let transition visibly begin
-        setTimeout(() => {
-          window.location.href = href;
-        }, 500); // Match CSS transition duration
-      });
-    });
-  });
-});
 
 window.addEventListener("load", () => {
   const overlay = document.querySelector(".page-transition-overlay");


### PR DESCRIPTION
## Summary
- merge the link interception and fade overlay code into the main `DOMContentLoaded` listener
- remove the later duplicate listener

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68517c113d60832cab875c097d9d8595