### PR TITLE
Add LICENSE and update README for preview instructions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 HK Bau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # HK Bau Website
 
-Professionelle Website für die Baufirma HK Bau – gebaut mit HTML, Tailwind CSS, und JavaScript.
+Professionelle Website für die Baufirma HK Bau – gebaut mit HTML, Tailwind CSS und JavaScript.
+Professional website for the construction company HK Bau – built with HTML, Tailwind CSS and JavaScript.
 
-## Features
+## Features / Eigenschaften
 - Moderne responsive Gestaltung
 - Parallax Hero Section
 - AOS-Animationen
 - Bild-Fallback für defekte Bilder
 - Scroll-to-Top Button
 
-## Projektstruktur
-/css/style.css  
-/js/app.js  
-/images/  
+## Projektstruktur / Project structure
+/css/style.css
+/js/app.js
+/images/
 
-## Lokale Entwicklung
-Öffnen Sie `index.html` im Browser oder hosten Sie das Projekt über Live Server (VSCode).
+## Lokale Entwicklung / Local preview
+Öffnen Sie `index.html` direkt im Browser oder starten Sie einen lokalen Server über VSCode Live Server oder `npx serve`.
 
-## Lizenz
-MIT
+## Lizenz / License
+Siehe [LICENSE](LICENSE)


### PR DESCRIPTION
## Summary
- add MIT LICENSE
- document local preview instructions in the README
- link to the LICENSE from the README

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68517c1bfec8832cb89e54c99c7f45d3