### PR TITLE
Add reusable contact demo handler

### DIFF
--- a/Website/kontakt.html
+++ b/Website/kontakt.html
@@ -201,16 +201,8 @@
 </main>
 
                 <script>
-                    document.getElementById("contactForm").addEventListener("submit", function (e) {
-                        e.preventDefault();
-                        const form = e.target;
-                        form.classList.add("animate-pulse");
-
-                        setTimeout(() => {
-                            form.classList.remove("animate-pulse");
-                            form.reset();
-                            document.getElementById("formSuccess").classList.remove("hidden");
-                        }, 1000);
+                    document.addEventListener("DOMContentLoaded", () => {
+                        handleContactDemo("contactForm");
                     });
                 </script>
                

--- a/js/app.js
+++ b/js/app.js
@@ -82,7 +82,25 @@ function initFormValidation(formId) {
         if (!emailRegex.test(email)) return console.error("Bitte geben Sie eine gültige E-Mail-Adresse ein.");
         if (message.length < 10) return console.error("Nachricht muss mindestens 10 Zeichen lang sein.");
 
-        console.log("Formular erfolgreich gesendet! (Demo-Modus)");
+    console.log("Formular erfolgreich gesendet! (Demo-Modus)");
+    });
+}
+
+// ========== Contact Form Demo Handler ============
+function handleContactDemo(formId) {
+    const form = document.getElementById(formId);
+    if (!form) return;
+
+    form.addEventListener("submit", (e) => {
+        e.preventDefault();
+        form.classList.add("animate-pulse");
+
+        setTimeout(() => {
+            form.classList.remove("animate-pulse");
+            form.reset();
+            const success = document.getElementById("formSuccess");
+            if (success) success.classList.remove("hidden");
+        }, 1000);
     });
 }
 


### PR DESCRIPTION
## Summary
- add new `handleContactDemo` helper in app.js
- call the handler from kontakt.html and remove inline logic
- keep loading `js/app.js` with the `defer` attribute

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851844c45b4832c8aa6f055e36190ad