### PR TITLE
Add theme-color meta tag

### DIFF
--- a/Website/404.html
+++ b/Website/404.html
@@ -8,6 +8,7 @@
   <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="../css/style.css" />
+  <meta name="theme-color" content="#FFD600">
 </head>
 <body class="min-h-screen flex flex-col bg-white text-gray-800">
   <header class="bg-secondary-color text-white py-4">

--- a/Website/datenschutzerklaerung.html
+++ b/Website/datenschutzerklaerung.html
@@ -65,6 +65,7 @@
   gtag('config', 'G-VK8HTW1N2L', { 'anonymize_ip': true });
 </script>
 
+  <meta name="theme-color" content="#FFD600">
 </head>
 
 

--- a/Website/impressum.html
+++ b/Website/impressum.html
@@ -64,6 +64,7 @@
   gtag('config', 'G-VK8HTW1N2L', { 'anonymize_ip': true });
 </script>
 
+  <meta name="theme-color" content="#FFD600">
 </head>
 
 

--- a/Website/index.html
+++ b/Website/index.html
@@ -66,6 +66,7 @@
   gtag('config', 'G-VK8HTW1N2L', { 'anonymize_ip': true });
 </script>
 
+  <meta name="theme-color" content="#FFD600">
 </head>
 
 

--- a/Website/karriere.html
+++ b/Website/karriere.html
@@ -67,6 +67,7 @@
   gtag('config', 'G-VK8HTW1N2L', { 'anonymize_ip': true });
 </script>
 
+  <meta name="theme-color" content="#FFD600">
 </head>
 
 <body class="text-[var(--secondary-color)]">

--- a/Website/kontakt.html
+++ b/Website/kontakt.html
@@ -69,6 +69,7 @@
   gtag('config', 'G-VK8HTW1N2L', { 'anonymize_ip': true });
 </script>
 
+  <meta name="theme-color" content="#FFD600">
 </head>
 
 <body class="font-[Inter]">

--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -67,6 +67,7 @@
   gtag('config', 'G-VK8HTW1N2L', { 'anonymize_ip': true });
 </script>
 
+  <meta name="theme-color" content="#FFD600">
 </head>
 
 <body class="font-[Inter] text-gray-800">

--- a/Website/referenzen.html
+++ b/Website/referenzen.html
@@ -68,6 +68,7 @@
   gtag('config', 'G-VK8HTW1N2L', { 'anonymize_ip': true });
 </script>
 
+  <meta name="theme-color" content="#FFD600">
 </head>
 
 

--- a/Website/wissen.html
+++ b/Website/wissen.html
@@ -106,6 +106,7 @@
   gtag('config', 'G-VK8HTW1N2L', { 'anonymize_ip': true });
 </script>
 
+  <meta name="theme-color" content="#FFD600">
 </head>
 
 <body class="font-[Inter]">

--- a/Website/wissen/betonieren-im-winter.html
+++ b/Website/wissen/betonieren-im-winter.html
@@ -51,6 +51,7 @@
 
   <!-- ✅ Your Custom CSS MUST come AFTER Tailwind -->
   <link rel="stylesheet" href="../../css/style.css" />
+  <meta name="theme-color" content="#FFD600">
 </head>
 
 


### PR DESCRIPTION
## Summary
- add theme-color meta to all HTML files

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685d510b304c832c843e8714ae19d63e