### PR TITLE
Remove unused lightbox CSS reference

### DIFF
--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -35,7 +35,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
     <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
     <link rel="stylesheet" href="../css/style.css" />
-    <link rel="stylesheet" href="../css/lightbox.css" />
  
     <!-- Cookie Consent by Osano -->
 <script defer src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js"></script>


### PR DESCRIPTION
## Summary
- remove `lightbox.css` stylesheet reference from leistungen page

## Testing
- `grep -R "lightbox.css" $(git ls-files)`

------
https://chatgpt.com/codex/tasks/task_e_685d5113f770832c8e3b6040b5abfec8