### PR TITLE
Remove unused hover-card styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -519,14 +519,6 @@ body, html {
     background-color: var(--primary-hover);
 }
 
-.hover-card {
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.hover-card:hover {
-    transform: scale(1.03);
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
-}
 
 /* Images (No color changes here) */
 img {


### PR DESCRIPTION
## Summary
- remove `.hover-card` styling from CSS

## Testing
- `grep -R "hover-card" -n`

------
https://chatgpt.com/codex/tasks/task_e_685d511c0e2c832c93479480bab6c7ca