### PR TITLE
Update README for website path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Professionelle Website für die Baufirma HK Bau – gebaut mit HTML, Tailwind CS
 - Scroll-to-Top Button
 
 ## Projektstruktur
-/css/style.css  
-/js/app.js  
-/images/  
+/Website/ (enthält alle HTML-Dateien)
+/css/style.css
+/js/app.js
+/images/
 
 ## Lokale Entwicklung
-Öffnen Sie `index.html` im Browser oder hosten Sie das Projekt über Live Server (VSCode).
+Öffnen Sie `Website/index.html` im Browser (z.B. `file:///pfad/zum/projekt/Website/index.html`) oder hosten Sie das Projekt über Live Server (VSCode).
 
 ## Lizenz
 Veröffentlicht unter der [MIT-Lizenz](LICENSE).


### PR DESCRIPTION
## Summary
- note that all HTML files live in the `Website/` directory
- include a quick example for launching `Website/index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e39b685ac832c8e2f1d85b9571f7b