### PR TITLE
Fix contact box shadow style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -838,7 +838,7 @@ img[src*="placeholder"] {
     padding: 0;
     background-color: transparent;
     border-radius: 0;
-    box-shadow: none(0, 0, 0, 0.05);
+    box-shadow: none;
 }
 
 #contact h3 {


### PR DESCRIPTION
## Summary
- fix invalid `box-shadow` declaration in contact info boxes

## Testing
- `python3 -m webbrowser Website/index.html` *(fails: no GUI)*

------
https://chatgpt.com/codex/tasks/task_e_685e39b62dec832cacdf35b2769974fe