### PR TITLE
Fix duplicate lazy loading attrs

### DIFF
--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -222,7 +222,7 @@
 
   <!-- Erdbau -->
   <div id="erdbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg group" data-aos="fade-up">
-    <img src="../images/erdbau.jpg" alt="Erdbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" loading="lazy" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Erdbau+Bild';" />
+    <img src="../images/erdbau.jpg" alt="Erdbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Erdbau+Bild';" />
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
         
@@ -249,13 +249,13 @@
       </ul>
       <a href="kontakt.html" class="inline-block bg-[var(--primary-color)] text-white font-semibold py-3 px-8 rounded-full shadow hover:shadow-xl transition duration-300 hover:bg-[var(--primary-hover)]">Unverbindliches Angebot anfragen</a>
     </div>
-    <img src="../images/kanalbau.jpg" alt="Kanalbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" loading="lazy" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Kanalbau+Bild';" />
+    <img src="../images/kanalbau.jpg" alt="Kanalbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Kanalbau+Bild';" />
   </div>
 
 
  <!-- Stahlbetonbau -->
   <div id="stahlbetonbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg group" data-aos="fade-up" data-aos-delay="150">
-    <img src="../images/stahlbetonbau.jpg" alt="Stahlbetonbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" loading="lazy" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Stahlbetonbau+Bild';" />
+    <img src="../images/stahlbetonbau.jpg" alt="Stahlbetonbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Stahlbetonbau+Bild';" />
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
         
@@ -287,7 +287,7 @@
 
   <!-- Holzbau -->
   <div id="holzbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg group" data-aos="fade-up" data-aos-delay="250">
-    <img src="../images/holzbau.webp" alt="Holzbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" loading="lazy" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Holzbau+Bild';" />
+    <img src="../images/holzbau.webp" alt="Holzbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Holzbau+Bild';" />
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
         
@@ -314,7 +314,7 @@
       </ul>
       <a href="kontakt.html" class="inline-block bg-[var(--primary-color)] text-white font-semibold py-3 px-8 rounded-full shadow hover:shadow-xl transition duration-300 hover:bg-[var(--primary-hover)]">Unverbindliches Angebot anfragen</a>
     </div>
-    <img src="../images/stahlbau.jpg" alt="Stahlbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" loading="lazy" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Stahlbau+Bild';" />
+    <img src="../images/stahlbau.jpg" alt="Stahlbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Stahlbau+Bild';" />
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- remove redundant `loading="lazy"` attributes in `Website/leistungen.html`

## Testing
- `grep -n "loading=\"lazy\"" Website/leistungen.html`

------
https://chatgpt.com/codex/tasks/task_e_685e3d56181c832cb66c7db8d7f34978