### PR TITLE
Add new Zielgruppen section

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -398,7 +398,51 @@
       </div>
     </section>
 
+    <!-- Zielgruppen Section -->
+    <section id="zielgruppen" class="py-24 bg-gradient-to-br from-gray-50 via-white to-gray-100">
+      <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 class="text-3xl sm:text-4xl font-bold text-center text-secondary-color mb-12">Zielgruppen</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
 
+          <!-- Privatkunden -->
+          <div class="flex flex-col p-6 bg-white rounded-xl shadow-md hover:shadow-xl transition">
+            <h3 class="text-xl font-bold text-secondary-color mb-2">Privatkunden</h3>
+            <p class="text-gray-600 mb-4">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-center text-secondary-color"><svg class="h-5 w-5 text-[var(--primary-color)] mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>Individuelle Beratung</li>
+              <li class="flex items-center text-secondary-color"><svg class="h-5 w-5 text-[var(--primary-color)] mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>Schlüsselfertiges Bauen</li>
+              <li class="flex items-center text-secondary-color"><svg class="h-5 w-5 text-[var(--primary-color)] mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>Transparente Kosten</li>
+            </ul>
+            <a href="leistungen/privatkunden.html" class="mt-auto inline-block bg-[var(--primary-color)] text-[var(--secondary-color)] font-semibold py-2 px-6 rounded-full btn-lift text-center">Mehr erfahren</a>
+          </div>
+
+          <!-- Architekten -->
+          <div class="flex flex-col p-6 bg-white rounded-xl shadow-md hover:shadow-xl transition">
+            <h3 class="text-xl font-bold text-secondary-color mb-2">Architekten</h3>
+            <p class="text-gray-600 mb-4">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-center text-secondary-color"><svg class="h-5 w-5 text-[var(--primary-color)] mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>Zuverlässige Ausführung</li>
+              <li class="flex items-center text-secondary-color"><svg class="h-5 w-5 text-[var(--primary-color)] mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>Technische Beratung</li>
+              <li class="flex items-center text-secondary-color"><svg class="h-5 w-5 text-[var(--primary-color)] mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>Termintreue Umsetzung</li>
+            </ul>
+            <a href="leistungen/architekten.html" class="mt-auto inline-block bg-[var(--primary-color)] text-[var(--secondary-color)] font-semibold py-2 px-6 rounded-full btn-lift text-center">Mehr erfahren</a>
+          </div>
+
+          <!-- Investoren -->
+          <div class="flex flex-col p-6 bg-white rounded-xl shadow-md hover:shadow-xl transition">
+            <h3 class="text-xl font-bold text-secondary-color mb-2">Investoren</h3>
+            <p class="text-gray-600 mb-4">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-center text-secondary-color"><svg class="h-5 w-5 text-[var(--primary-color)] mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>Wirtschaftliche Planung</li>
+              <li class="flex items-center text-secondary-color"><svg class="h-5 w-5 text-[var(--primary-color)] mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>Hohe Rendite</li>
+              <li class="flex items-center text-secondary-color"><svg class="h-5 w-5 text-[var(--primary-color)] mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>Professionelles Projektmanagement</li>
+            </ul>
+            <a href="leistungen/investoren.html" class="mt-auto inline-block bg-[var(--primary-color)] text-[var(--secondary-color)] font-semibold py-2 px-6 rounded-full btn-lift text-center">Mehr erfahren</a>
+          </div>
+
+        </div>
+      </div>
+    </section>
 
 
     <section id="projects" class="py-24 bg-gradient-to-br from-gray-50 via-white to-gray-100">

--- a/Website/leistungen/architekten.html
+++ b/Website/leistungen/architekten.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Architekten – HK Bau</title>
+  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="../css/style.css" />
+  <meta name="theme-color" content="#FFD600">
+</head>
+<body class="font-[Inter] text-secondary-color overflow-x-hidden">
+  <header class="bg-secondary-color text-white py-4">
+    <div class="max-w-7xl mx-auto px-4">
+      <a href="../index.html" class="font-bold">HK Bau</a>
+    </div>
+  </header>
+  <main class="py-24 text-center">
+    <div class="max-w-2xl mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-4">Architekten</h1>
+      <p class="text-gray-600">Hier entsteht eine neue Unterseite.</p>
+    </div>
+  </main>
+  <footer class="bg-secondary-color text-text-on-dark text-center py-4">
+    <p>© <span class="current-year"></span> HK Bau GmbH</p>
+  </footer>
+  <script src="../js/app.js" defer></script>
+</body>
+</html>

--- a/Website/leistungen/investoren.html
+++ b/Website/leistungen/investoren.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Investoren – HK Bau</title>
+  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="../css/style.css" />
+  <meta name="theme-color" content="#FFD600">
+</head>
+<body class="font-[Inter] text-secondary-color overflow-x-hidden">
+  <header class="bg-secondary-color text-white py-4">
+    <div class="max-w-7xl mx-auto px-4">
+      <a href="../index.html" class="font-bold">HK Bau</a>
+    </div>
+  </header>
+  <main class="py-24 text-center">
+    <div class="max-w-2xl mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-4">Investoren</h1>
+      <p class="text-gray-600">Hier entsteht eine neue Unterseite.</p>
+    </div>
+  </main>
+  <footer class="bg-secondary-color text-text-on-dark text-center py-4">
+    <p>© <span class="current-year"></span> HK Bau GmbH</p>
+  </footer>
+  <script src="../js/app.js" defer></script>
+</body>
+</html>

--- a/Website/leistungen/privatkunden.html
+++ b/Website/leistungen/privatkunden.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privatkunden – HK Bau</title>
+  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="../css/style.css" />
+  <meta name="theme-color" content="#FFD600">
+</head>
+<body class="font-[Inter] text-secondary-color overflow-x-hidden">
+  <header class="bg-secondary-color text-white py-4">
+    <div class="max-w-7xl mx-auto px-4">
+      <a href="../index.html" class="font-bold">HK Bau</a>
+    </div>
+  </header>
+  <main class="py-24 text-center">
+    <div class="max-w-2xl mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-4">Privatkunden</h1>
+      <p class="text-gray-600">Hier entsteht eine neue Unterseite.</p>
+    </div>
+  </main>
+  <footer class="bg-secondary-color text-text-on-dark text-center py-4">
+    <p>© <span class="current-year"></span> HK Bau GmbH</p>
+  </footer>
+  <script src="../js/app.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a new "Zielgruppen" section on the homepage with three cards
- add placeholder subpages for Privatkunden, Architekten and Investoren

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e700d78ac832c98a60fdfe20dd1c8