### PR TITLE
Add AOS animations to 'Wir schaffen' section

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -140,18 +140,18 @@
 
     
 
-<section class="bg-gray-50 py-16">
+<section class="bg-gray-50 py-16" data-aos="fade-up">
   <div class="max-w-screen-xl mx-auto px-4 text-center">
-    <h2 class="text-3xl md:text-4xl font-bold text-neutral-900 mb-10 relative inline-block">
+    <h2 class="text-3xl md:text-4xl font-bold text-neutral-900 mb-10 relative inline-block" data-aos="fade-down" data-aos-delay="100">
       Wir schaffen
       <span class="block w-full h-1 bg-yellow-400 mx-auto mt-2 rounded-full"></span>
     </h2>
 
     <div class="relative services-carousel">
       <div class="overflow-hidden">
-        <div class="carousel-wrapper flex transition-transform duration-700 ease-in-out">
+        <div class="carousel-wrapper flex transition-transform duration-700 ease-in-out" data-aos="fade-up" data-aos-delay="200">
           <!-- Repeat these slides (7 total as needed) -->
-          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0">
+          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0" data-aos="fade-up" data-aos-delay="300">
             <div class="bg-white p-4 rounded-lg shadow text-center">
               <div class="w-full h-48 bg-gray-200 rounded-lg mb-4"></div>
               <h3 class="text-xl font-semibold mb-2">Wohnungsbau</h3>
@@ -159,7 +159,7 @@
             </div>
           </div>
 
-          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0">
+          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0" data-aos="fade-up" data-aos-delay="400">
             <div class="bg-white p-4 rounded-lg shadow text-center">
               <div class="w-full h-48 bg-gray-200 rounded-lg mb-4"></div>
               <h3 class="text-xl font-semibold mb-2">Gewerblicher Hochbau</h3>
@@ -167,7 +167,7 @@
             </div>
           </div>
 
-          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0">
+          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0" data-aos="fade-up" data-aos-delay="500">
             <div class="bg-white p-4 rounded-lg shadow text-center">
               <div class="w-full h-48 bg-gray-200 rounded-lg mb-4"></div>
               <h3 class="text-xl font-semibold mb-2">Öffentlicher Hochbau</h3>
@@ -177,7 +177,7 @@
 
           <!-- Add more blocks below (up to 7-8 total) -->
 
-          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0">
+          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0" data-aos="fade-up" data-aos-delay="600">
             <div class="bg-white p-4 rounded-lg shadow text-center">
               <div class="w-full h-48 bg-gray-200 rounded-lg mb-4"></div>
               <h3 class="text-xl font-semibold mb-2">Hallenbau</h3>
@@ -185,7 +185,7 @@
             </div>
           </div>
 
-          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0">
+          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0" data-aos="fade-up" data-aos-delay="700">
             <div class="bg-white p-4 rounded-lg shadow text-center">
               <div class="w-full h-48 bg-gray-200 rounded-lg mb-4"></div>
               <h3 class="text-xl font-semibold mb-2">Modul- & Fertigteilbau</h3>
@@ -193,7 +193,7 @@
             </div>
           </div>
 
-          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0">
+          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0" data-aos="fade-up" data-aos-delay="800">
             <div class="bg-white p-4 rounded-lg shadow text-center">
               <div class="w-full h-48 bg-gray-200 rounded-lg mb-4"></div>
               <h3 class="text-xl font-semibold mb-2">Sanierung & Umbau</h3>
@@ -201,7 +201,7 @@
             </div>
           </div>
 
-          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0">
+          <div class="carousel-slide w-full md:w-1/3 px-4 flex-shrink-0" data-aos="fade-up" data-aos-delay="900">
             <div class="bg-white p-4 rounded-lg shadow text-center">
               <div class="w-full h-48 bg-gray-200 rounded-lg mb-4"></div>
               <h3 class="text-xl font-semibold mb-2">Schlüsselfertigbau</h3>


### PR DESCRIPTION
## Summary
- animate the "Wir schaffen" section on the homepage
- added fade-up effect on the section and carousel wrapper
- added fade-down effect to the heading
- animated each carousel slide with incremental delay

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ea69d8140832c8cbf0d935f43f37a