### PR TITLE
Add client type section

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -136,9 +136,7 @@
         <p class="text-lg md:text-xl mb-6">Ihr zuverlässiger Partner im Bauwesen</p>
         <h1 class="text-4xl md:text-6xl font-bold mb-10">Wo vision auf fundament trifft.</h1>
       </div>
-    </section>
-
-    
+    </section>    
 
 <section class="bg-gray-50 py-16">
   <div class="max-w-screen-xl mx-auto px-4 text-center">
@@ -383,7 +381,55 @@
       </div>
     </section>
 
+    <!-- Kundenarten Section -->
+    <section id="message-to-clients" class="py-24 bg-gray-50">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 class="text-3xl sm:text-4xl font-bold text-center text-[var(--secondary-color)] mb-12" data-aos="fade-up">
+          Für wen wir bauen
+        </h2>
 
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <!-- Privatkunden Card -->
+          <div class="group flex flex-col bg-white p-6 rounded-xl shadow-md hover:shadow-lg transition transform hover:-translate-y-1" data-aos="fade-up" data-aos-delay="100">
+            <div class="text-[var(--primary-color)] text-4xl mb-4" data-aos="zoom-in" data-aos-delay="200">
+              <i class="fas fa-home" aria-hidden="true"></i>
+            </div>
+            <h3 class="text-xl font-semibold mb-2">Privatkunden</h3>
+            <p class="text-gray-600 mb-6">Von der Planung bis zur Schlüsselübergabe begleiten wir Ihr persönliches Bauprojekt.</p>
+            <a href="leistungen/privatkunden.html" class="mt-auto inline-flex items-center text-[var(--primary-color)] font-semibold group hover:underline" aria-label="Mehr über Privatkunden erfahren">
+              Mehr erfahren
+              <span class="ml-1 transition-transform group-hover:translate-x-1" aria-hidden="true">→</span>
+            </a>
+          </div>
+
+          <!-- Architekten Card -->
+          <div class="group flex flex-col bg-white p-6 rounded-xl shadow-md hover:shadow-lg transition transform hover:-translate-y-1" data-aos="fade-up" data-aos-delay="200">
+            <div class="text-[var(--primary-color)] text-4xl mb-4" data-aos="zoom-in" data-aos-delay="300">
+              <i class="fas fa-drafting-compass" aria-hidden="true"></i>
+            </div>
+            <h3 class="text-xl font-semibold mb-2">Architekten</h3>
+            <p class="text-gray-600 mb-6">Gemeinsam realisieren wir anspruchsvolle Entwürfe und setzen auf Präzision.</p>
+            <a href="leistungen/architekten.html" class="mt-auto inline-flex items-center text-[var(--primary-color)] font-semibold group hover:underline" aria-label="Mehr über Architekten erfahren">
+              Mehr erfahren
+              <span class="ml-1 transition-transform group-hover:translate-x-1" aria-hidden="true">→</span>
+            </a>
+          </div>
+
+          <!-- Investoren Card -->
+          <div class="group flex flex-col bg-white p-6 rounded-xl shadow-md hover:shadow-lg transition transform hover:-translate-y-1" data-aos="fade-up" data-aos-delay="300">
+            <div class="text-[var(--primary-color)] text-4xl mb-4" data-aos="zoom-in" data-aos-delay="400">
+              <i class="fas fa-chart-line" aria-hidden="true"></i>
+            </div>
+            <h3 class="text-xl font-semibold mb-2">Investoren</h3>
+            <p class="text-gray-600 mb-6">Wir schaffen wertbeständige Bauten, die wirtschaftlich überzeugen.</p>
+            <a href="leistungen/investoren.html" class="mt-auto inline-flex items-center text-[var(--primary-color)] font-semibold group hover:underline" aria-label="Mehr über Investoren erfahren">
+              Mehr erfahren
+              <span class="ml-1 transition-transform group-hover:translate-x-1" aria-hidden="true">→</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
 
 
     <section id="projects" class="py-24 bg-gradient-to-br from-gray-50 via-white to-gray-100">


### PR DESCRIPTION
## Summary
- add new message-to-clients section listing Privatkunden, Architekten and Investoren with Font Awesome icons
- include AOS animations and hover transitions
- ensure mobile-friendly grid and consistent color variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eb56949bc832c8e83b0a638ebd96b