### PR TITLE
Use secondary color for impressum navbar

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -32,7 +32,7 @@ function initStickyHeader(navbarId) {
 
     const isImpressum = document.body.classList.contains("impressum-page");
     if (isImpressum) {
-        navbar.classList.add("bg-[#1f1f1f]");
+        navbar.style.backgroundColor = "var(--secondary-color)";
         return;
     }
 


### PR DESCRIPTION
## Summary
- ensure the impressum navbar uses the `--secondary-color` CSS variable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686683f41b8c832c9fb541495c7acfd4