### PR TITLE
Add hero sections to placeholder pages

### DIFF
--- a/Website/leistungen/architekten.html
+++ b/Website/leistungen/architekten.html
@@ -15,11 +15,30 @@
       <a href="../index.html" class="font-bold">HK Bau</a>
     </div>
   </header>
-  <main class="py-24 text-center">
-    <div class="max-w-2xl mx-auto px-4">
-      <h1 class="text-3xl font-bold mb-4">Architekten</h1>
-      <p class="text-gray-600">Hier entsteht eine neue Unterseite.</p>
-    </div>
+  <main>
+    <section class="relative h-screen overflow-hidden flex items-center justify-center parallax leistungen-hero pt-16">
+
+        <div class="absolute inset-0 z-0 overflow-hidden">
+            <img src="../images/pexels-sevenstormphotography-439416.jpg" alt="Hero Hintergrund"
+                class="w-full h-full object-cover zoom-parallax" />
+            <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" />
+            <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+
+        </div>
+
+        <div class="relative z-10 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
+            <h1 class="text-4xl md:text-6xl font-bold mb-4 drop-shadow-lg">Architekten</h1>
+            <p class="text-lg md:text-xl max-w-2xl mx-auto mb-8 opacity-90">Qualität, Präzision und Erfahrung für
+                Ihre Projekte in Sindelfingen
+                und Stuttgart</p>
+        </div>
+    </section>
+
+    <section class="py-24 text-center">
+      <div class="max-w-2xl mx-auto px-4">
+        <p class="text-gray-600">Hier entsteht eine neue Unterseite.</p>
+      </div>
+    </section>
   </main>
   <footer class="bg-secondary-color text-text-on-dark text-center py-4">
     <p>© <span class="current-year"></span> HK Bau GmbH</p>

--- a/Website/leistungen/investoren.html
+++ b/Website/leistungen/investoren.html
@@ -15,11 +15,30 @@
       <a href="../index.html" class="font-bold">HK Bau</a>
     </div>
   </header>
-  <main class="py-24 text-center">
-    <div class="max-w-2xl mx-auto px-4">
-      <h1 class="text-3xl font-bold mb-4">Investoren</h1>
-      <p class="text-gray-600">Hier entsteht eine neue Unterseite.</p>
-    </div>
+  <main>
+    <section class="relative h-screen overflow-hidden flex items-center justify-center parallax leistungen-hero pt-16">
+
+        <div class="absolute inset-0 z-0 overflow-hidden">
+            <img src="../images/pexels-sevenstormphotography-439416.jpg" alt="Hero Hintergrund"
+                class="w-full h-full object-cover zoom-parallax" />
+            <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" />
+            <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+
+        </div>
+
+        <div class="relative z-10 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
+            <h1 class="text-4xl md:text-6xl font-bold mb-4 drop-shadow-lg">Investoren</h1>
+            <p class="text-lg md:text-xl max-w-2xl mx-auto mb-8 opacity-90">Qualität, Präzision und Erfahrung für
+                Ihre Projekte in Sindelfingen
+                und Stuttgart</p>
+        </div>
+    </section>
+
+    <section class="py-24 text-center">
+      <div class="max-w-2xl mx-auto px-4">
+        <p class="text-gray-600">Hier entsteht eine neue Unterseite.</p>
+      </div>
+    </section>
   </main>
   <footer class="bg-secondary-color text-text-on-dark text-center py-4">
     <p>© <span class="current-year"></span> HK Bau GmbH</p>

--- a/Website/leistungen/privatkunden.html
+++ b/Website/leistungen/privatkunden.html
@@ -15,11 +15,30 @@
       <a href="../index.html" class="font-bold">HK Bau</a>
     </div>
   </header>
-  <main class="py-24 text-center">
-    <div class="max-w-2xl mx-auto px-4">
-      <h1 class="text-3xl font-bold mb-4">Privatkunden</h1>
-      <p class="text-gray-600">Hier entsteht eine neue Unterseite.</p>
-    </div>
+  <main>
+    <section class="relative h-screen overflow-hidden flex items-center justify-center parallax leistungen-hero pt-16">
+
+        <div class="absolute inset-0 z-0 overflow-hidden">
+            <img src="../images/pexels-sevenstormphotography-439416.jpg" alt="Hero Hintergrund"
+                class="w-full h-full object-cover zoom-parallax" />
+            <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" />
+            <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+
+        </div>
+
+        <div class="relative z-10 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
+            <h1 class="text-4xl md:text-6xl font-bold mb-4 drop-shadow-lg">Privatkunden</h1>
+            <p class="text-lg md:text-xl max-w-2xl mx-auto mb-8 opacity-90">Qualität, Präzision und Erfahrung für
+                Ihre Projekte in Sindelfingen
+                und Stuttgart</p>
+        </div>
+    </section>
+
+    <section class="py-24 text-center">
+      <div class="max-w-2xl mx-auto px-4">
+        <p class="text-gray-600">Hier entsteht eine neue Unterseite.</p>
+      </div>
+    </section>
   </main>
   <footer class="bg-secondary-color text-text-on-dark text-center py-4">
     <p>© <span class="current-year"></span> HK Bau GmbH</p>


### PR DESCRIPTION
## Summary
- add consistent hero markup to Architekten, Investoren and Privatkunden

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686683f492b8832c8c729095246a7e8d