### PR TITLE
Add utility color classes

### DIFF
--- a/Website/kontakt.html
+++ b/Website/kontakt.html
@@ -192,7 +192,7 @@
                 class="w-full p-3 rounded-lg border border-gray-300 shadow-sm focus:ring-2 focus:ring-[var(--primary-color)]"></textarea>
 
             <button type="submit"
-                class="w-full bg-[var(--primary-color)] text-white font-semibold py-3 px-6 rounded-lg hover:bg-yellow-600 transition shadow-xl hover:scale-105 transform duration-300"
+                class="w-full bg-primary-color text-secondary-color font-semibold py-3 px-6 rounded-lg hover:bg-yellow-600 transition shadow-xl hover:scale-105 transform duration-300"
                 data-aos="fade-up" data-aos-delay="1000">
                 Nachricht senden
             </button>

--- a/css/style.css
+++ b/css/style.css
@@ -15,6 +15,13 @@
     /* Light gray text for dark backgrounds (e.g., footer) */
 }
 
+/* Reusable color utility classes */
+.text-primary-color    { color: var(--primary-color) !important; }
+.text-secondary-color  { color: var(--secondary-color) !important; }
+.text-tertiary-color   { color: var(--tertiary-color) !important; }
+.bg-primary-color      { background-color: var(--primary-color) !important; }
+.bg-secondary-color    { background-color: var(--secondary-color) !important; }
+
 html {
     scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Summary
- add reusable text and background color classes in `style.css`
- use new utility class for contact page submit button

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686683f1fa24832c91390426c2461816