### PR TITLE
Update primary color references

### DIFF
--- a/css/modern-style.css
+++ b/css/modern-style.css
@@ -1,16 +1,16 @@
 /* Modern CSS Variables with Extended Color Palette */
 :root {
     /* Primary Colors */
-    --primary-50: #fffbeb;
-    --primary-100: #fef3c7;
-    --primary-200: #fde68a;
-    --primary-300: #fcd34d;
-    --primary-400: #fbbf24;
-    --primary-500: #fbbb21;
-    --primary-600: #d97706;
-    --primary-700: #b45309;
-    --primary-800: #92400e;
-    --primary-900: #78350f;
+    --primary-50: var(--primary-color);
+    --primary-100: var(--primary-color);
+    --primary-200: var(--primary-color);
+    --primary-300: var(--primary-color);
+    --primary-400: var(--primary-color);
+    --primary-500: var(--primary-color);
+    --primary-600: var(--primary-color);
+    --primary-700: var(--primary-color);
+    --primary-800: var(--primary-color);
+    --primary-900: var(--primary-color);
     
     /* Neutral Colors */
     --neutral-50: #fafafa;
@@ -26,7 +26,7 @@
     
     /* Semantic Colors */
     --success: #10b981;
-    --warning: #fbbb21;
+    --warning: var(--primary-color);
     --error: #ef4444;
     --info: #3b82f6;
     

--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 :root {
     --primary-color: #fbbb21;
     /* Brand yellow */
-    --primary-hover: #e0a800;
+    --primary-hover: var(--primary-color);
     /* Slightly darker yellow for hover */
     --secondary-color: #3B454E;
     /* Brand dark gray */

--- a/mockups/contact-page.html
+++ b/mockups/contact-page.html
@@ -8,10 +8,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>
         body { font-family: 'Inter', sans-serif; }
-        .gradient-bg { background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%); }
+        .gradient-bg { background: linear-gradient(135deg, #fbbb21 0%, #fbbb21 100%); }
         .glass { backdrop-filter: blur(20px); background: rgba(255, 255, 255, 0.1); }
         .form-input { transition: all 0.3s ease; }
-        .form-input:focus { transform: translateY(-2px); box-shadow: 0 10px 25px rgba(245, 158, 11, 0.15); }
+        .form-input:focus { transform: translateY(-2px); box-shadow: 0 10px 25px rgba(251, 187, 33, 0.15); }
     </style>
 </head>
 <body class="bg-gray-50">

--- a/mockups/modern-homepage.html
+++ b/mockups/modern-homepage.html
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>
         body { font-family: 'Inter', sans-serif; }
-        .gradient-bg { background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%); }
+        .gradient-bg { background: linear-gradient(135deg, #fbbb21 0%, #fbbb21 100%); }
         .glass { backdrop-filter: blur(20px); background: rgba(255, 255, 255, 0.1); }
         .card-hover { transition: all 0.3s ease; }
         .card-hover:hover { transform: translateY(-8px); box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25); }

--- a/mockups/services-page.html
+++ b/mockups/services-page.html
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>
         body { font-family: 'Inter', sans-serif; }
-        .gradient-bg { background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%); }
+        .gradient-bg { background: linear-gradient(135deg, #fbbb21 0%, #fbbb21 100%); }
         .glass { backdrop-filter: blur(20px); background: rgba(255, 255, 255, 0.1); }
         .service-card { transition: all 0.4s ease; }
         .service-card:hover { transform: translateY(-12px) scale(1.02); }


### PR DESCRIPTION
## Summary
- unify hover color to `var(--primary-color)` in `style.css`
- link all modern palette colors to primary color in `modern-style.css`
- adjust mockup gradient colors and shadows to use brand yellow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686775842d8c832c81973a97e7bede07