### PR TITLE
Add missing labels on index contact form

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -555,9 +555,18 @@
             </div>
           </div>
           <form id="contactForm" class="space-y-6 bg-white p-6 rounded-xl shadow-md" action="#" method="POST">
-            <input type="text" placeholder="Ihr Name" required class="w-full p-3 rounded-lg border">
-            <input type="email" placeholder="Ihre E-Mail-Adresse" required class="w-full p-3 rounded-lg border">
-            <textarea rows="5" placeholder="Ihre Nachricht" required class="w-full p-3 rounded-lg border"></textarea>
+            <label for="name" class="block text-sm font-semibold">Name</label>
+            <input type="text" id="name" name="name" placeholder="Ihr Name" required
+              class="w-full p-3 rounded-lg border border-gray-300 shadow-sm focus:ring-2 focus:ring-[var(--primary-color)]">
+
+            <label for="email" class="block text-sm font-semibold">E-Mail</label>
+            <input type="email" id="email" name="email" placeholder="Ihre E-Mail-Adresse" required
+              class="w-full p-3 rounded-lg border border-gray-300 shadow-sm focus:ring-2 focus:ring-[var(--primary-color)]">
+
+            <label for="message" class="block text-sm font-semibold">Nachricht</label>
+            <textarea id="message" name="message" rows="5" placeholder="Ihre Nachricht" required
+              class="w-full p-3 rounded-lg border border-gray-300 shadow-sm focus:ring-2 focus:ring-[var(--primary-color)]"></textarea>
+
             <button type="submit"
               class="w-full bg-primary-color text-secondary-color font-semibold py-3 px-6 rounded-lg transition">Nachricht
               senden</button>


### PR DESCRIPTION
## Summary
- add `<label>` elements and matching `id` attributes for contact form inputs on the home page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867a78705f4832cb82213508c2e4cc5