### PR TITLE
Remove duplicate overlay on career page

### DIFF
--- a/Website/karriere.html
+++ b/Website/karriere.html
@@ -71,8 +71,8 @@
 </head>
 
 <body class="text-[var(--secondary-color)] overflow-x-hidden">
-    <div id="pageTransitionOverlay" class="page-transition-overlay"></div>
-<div class="page-transition-overlay flex items-center justify-center">
+    
+<div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
       <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />


### PR DESCRIPTION
## Summary
- ensure karriere.html uses only one page transition overlay element

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867a9bccfe0832cb1c118b39140e414