### PR TITLE
Fix GLightbox link handling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -502,7 +502,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const overlay = document.querySelector(".page-transition-overlay");
     if (overlay) {
-        const links = document.querySelectorAll("a[href]");
+        const links = document.querySelectorAll("a[href]:not(.glightbox)");
         links.forEach(link => {
             const href = link.getAttribute("href");
             if (


### PR DESCRIPTION
## Summary
- avoid transition overlay for GLightbox links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cbe8fb534832ca95568ba4713b1a9