### PR TITLE
Fix carousel JS initialization

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -77,6 +77,7 @@ function applyThemeColor() {
 
 // ======== GLightbox Initialization ============
 function initLightbox() {
+  if (typeof window.GLightbox !== 'function') return;
   GLightbox({
     selector: '.glightbox',
     openEffect: 'zoom',
@@ -358,7 +359,7 @@ function initServicesCarousel() {
         autoSlideInterval = setInterval(() => {
             currentIndex = (currentIndex + 1) % totalGroups;
             updateCarousel();
-        }, 6000);
+        }, 5000);
     }
 
     function resetAutoSlide() {


### PR DESCRIPTION
## Summary
- avoid errors when `GLightbox` library isn't loaded
- use a 5 second interval for services carousel autoplay

## Testing
- `node -e "require('fs').readFileSync('js/app.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_686cd711467c832c887f0f6f21b27319