### PR TITLE
Add animated counter helper

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -517,6 +517,35 @@ function initCounters() {
     counters.forEach(counter => observer.observe(counter));
 }
 
+// ========== Animated Counters (IntersectionObserver) ============
+function initAnimatedCounters() {
+    const counters = document.querySelectorAll('.counter');
+    if (counters.length === 0) return;
+
+    const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                const el = entry.target;
+                const target = parseInt(el.getAttribute('data-count'), 10) || 0;
+                let current = 0;
+                const increment = Math.max(1, Math.floor(target / 50));
+                const interval = setInterval(() => {
+                    current += increment;
+                    if (current >= target) {
+                        el.textContent = target;
+                        clearInterval(interval);
+                    } else {
+                        el.textContent = current;
+                    }
+                }, 30);
+                observer.unobserve(el);
+            }
+        });
+    }, { threshold: 0.6 });
+
+    counters.forEach(counter => observer.observe(counter));
+}
+
 // ========== DOMContentLoaded Bootstrap ============
 document.addEventListener("DOMContentLoaded", () => {
     AOS.init({
@@ -537,7 +566,7 @@ document.addEventListener("DOMContentLoaded", () => {
     initProjectCarousel();
     initServicesCarousel();
        initWirSchaffenCarousel();
-    initCounters();
+    initAnimatedCounters();
 
     window.addEventListener("hashchange", setActiveLink);
 


### PR DESCRIPTION
## Summary
- add a dedicated `initAnimatedCounters` helper in `app.js`
- call `initAnimatedCounters()` when the DOM is ready

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cebd0bf98832c808e3acfc6216fe3