### PR TITLE
Fix hero overlay, counters, and mobile nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Professionelle Website für die Baufirma HK Bau – gebaut mit HTML, Tailwind CS
 - AOS-Animationen
 - Bild-Fallback für defekte Bilder
 - Scroll-to-Top Button
+- Lazy Loading für Bilder
+- Slide-in Mobile Navigation
+- Animierte Counter
 
 ## Projektstruktur
 /Website/ (enthält alle HTML-Dateien)

--- a/Website/datenschutzerklaerung.html
+++ b/Website/datenschutzerklaerung.html
@@ -73,7 +73,7 @@
 <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
-      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
     </div>
     <span class="text-white text-sm tracking-wide">Lädt...</span>
   </div>
@@ -103,7 +103,7 @@
                 </svg>
             </button>
         </div>
-        <div class="md:hidden hidden" id="mobile-menu">
+        <div id="mobile-menu" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                 <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
                 <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>

--- a/Website/impressum.html
+++ b/Website/impressum.html
@@ -72,7 +72,7 @@
 <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
-      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
     </div>
     <span class="text-white text-sm tracking-wide">Lädt...</span>
   </div>
@@ -104,7 +104,7 @@
         </svg>
       </button>
     </div>
-    <div class="md:hidden hidden" id="mobile-menu">
+    <div id="mobile-menu" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out">
       <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
         <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
         <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>

--- a/Website/index.html
+++ b/Website/index.html
@@ -84,7 +84,7 @@
     <div class="flex flex-col items-center space-y-4 animate-fade-in">
       <div
         class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
-        <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
       </div>
       <span class="text-white text-sm tracking-wide">Lädt...</span>
     </div>
@@ -114,7 +114,7 @@
       </button>
     </div>
 
-    <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden hidden">
+    <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out">
       <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
         <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
         <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
@@ -126,13 +126,11 @@
     </nav>
   </header>
   <main>
-    <section id="home" class="relative h-screen flex items-center justify-center parallax">
-      <div
-        class="absolute inset-0 bg-gradient-to-b from-[var(--secondary-color)]/70 to-[var(--secondary-color)]/30 z-0">
-      </div>
-      <img src="../images/pexels-sevenstormphotography-439416.jpg" alt="Bauprojekt"
-        class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" loading="lazy" />
-      <div class="relative z-10 text-center px-6 max-w-2xl hero-content" data-aos="zoom-in">
+  <section id="home" class="relative h-screen flex items-center justify-center parallax">
+      <div class="absolute inset-0 bg-gradient-to-b from-[var(--secondary-color)]/70 to-[var(--secondary-color)]/30 z-0"></div>
+      <img src="../images/pexels-sevenstormphotography-439416.jpg" alt="Bauprojekt" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" loading="lazy" />
+      <div class="absolute inset-0 bg-black/60 z-10"></div>
+      <div class="relative z-20 text-center px-6 max-w-2xl hero-content" data-aos="zoom-in">
         <p class="text-lg md:text-xl mb-6">Ihr zuverlässiger Partner im Bauwesen</p>
         <h1 class="text-4xl md:text-6xl font-bold mb-10">Wo Vision auf Fundament trifft.</h1>
       </div>
@@ -144,7 +142,7 @@
       <!-- Section Heading -->
       <div class="text-center mb-10">
         <h2 class="text-3xl md:text-4xl font-extrabold tracking-tight text-neutral-900 dark:text-white">
-          Wir <span class="text-[var(--primary-color)]">schaffen</span>
+          Wir <span class="bg-neutral-900 px-2 rounded text-yellow-400 drop-shadow-md">schaffen</span>
         </h2>
         <div class="w-24 h-1 bg-[var(--primary-color)] mx-auto mt-2 rounded-full"></div>
       </div>
@@ -157,19 +155,19 @@
             <div class="carousel-slide w-full flex-shrink-0 flex justify-center gap-4">
               <!-- Card 1 -->
               <div class="bg-white dark:bg-neutral-800 p-5 rounded-xl shadow text-center transition hover:shadow-lg w-full max-w-xs">
-                <img src="/images/demo1.jpg" alt="Wohnungsbau" class="w-full h-48 object-cover rounded-md mb-4">
+                <img src="/images/demo1.jpg" alt="Wohnungsbau" class="w-full h-48 object-cover rounded-md mb-4" loading="lazy">
                 <h3 class="text-lg font-semibold text-neutral-900 dark:text-white">Wohnungsbau</h3>
                 <p class="text-sm text-gray-600 dark:text-gray-300">Wohnanlagen, Ein- & Mehrfamilienhäuser</p>
               </div>
               <!-- Card 2 -->
               <div class="bg-white dark:bg-neutral-800 p-5 rounded-xl shadow text-center transition hover:shadow-lg w-full max-w-xs">
-                <img src="/images/demo2.jpg" alt="Gewerblicher Hochbau" class="w-full h-48 object-cover rounded-md mb-4">
+                <img src="/images/demo2.jpg" alt="Gewerblicher Hochbau" class="w-full h-48 object-cover rounded-md mb-4" loading="lazy">
                 <h3 class="text-lg font-semibold text-neutral-900 dark:text-white">Gewerblicher Hochbau</h3>
                 <p class="text-sm text-gray-600 dark:text-gray-300">Bürogebäude, Einkaufshäuser, Industriebauten</p>
               </div>
               <!-- Card 3 -->
               <div class="bg-white dark:bg-neutral-800 p-5 rounded-xl shadow text-center transition hover:shadow-lg w-full max-w-xs">
-                <img src="/images/demo3.jpg" alt="Öffentlicher Hochbau" class="w-full h-48 object-cover rounded-md mb-4">
+                <img src="/images/demo3.jpg" alt="Öffentlicher Hochbau" class="w-full h-48 object-cover rounded-md mb-4" loading="lazy">
                 <h3 class="text-lg font-semibold text-neutral-900 dark:text-white">Öffentlicher Hochbau</h3>
                 <p class="text-sm text-gray-600 dark:text-gray-300">Rathäuser, Gesundheitszentren, Schulgebäude</p>
               </div>
@@ -179,19 +177,19 @@
             <div class="carousel-slide w-full flex-shrink-0 flex justify-center gap-4">
               <!-- Card 4 -->
               <div class="bg-white dark:bg-neutral-800 p-5 rounded-xl shadow text-center transition hover:shadow-lg w-full max-w-xs">
-                <img src="/images/demo4.jpg" alt="Hallenbau" class="w-full h-48 object-cover rounded-md mb-4">
+                <img src="/images/demo4.jpg" alt="Hallenbau" class="w-full h-48 object-cover rounded-md mb-4" loading="lazy">
                 <h3 class="text-lg font-semibold text-neutral-900 dark:text-white">Hallenbau</h3>
                 <p class="text-sm text-gray-600 dark:text-gray-300">Produktionshallen, Lagerhallen, Parkhäuser</p>
               </div>
               <!-- Card 5 -->
               <div class="bg-white dark:bg-neutral-800 p-5 rounded-xl shadow text-center transition hover:shadow-lg w-full max-w-xs">
-                <img src="/images/demo5.jpg" alt="Modul- & Fertigteilbau" class="w-full h-48 object-cover rounded-md mb-4">
+                <img src="/images/demo5.jpg" alt="Modul- & Fertigteilbau" class="w-full h-48 object-cover rounded-md mb-4" loading="lazy">
                 <h3 class="text-lg font-semibold text-neutral-900 dark:text-white">Modul- & Fertigteilbau</h3>
                 <p class="text-sm text-gray-600 dark:text-gray-300">Pflegewohnheime, Studentenwohnheime, Appartements</p>
               </div>
               <!-- Card 6 -->
               <div class="bg-white dark:bg-neutral-800 p-5 rounded-xl shadow text-center transition hover:shadow-lg w-full max-w-xs">
-                <img src="/images/demo6.jpg" alt="Sanierung & Umbau" class="w-full h-48 object-cover rounded-md mb-4">
+                <img src="/images/demo6.jpg" alt="Sanierung & Umbau" class="w-full h-48 object-cover rounded-md mb-4" loading="lazy">
                 <h3 class="text-lg font-semibold text-neutral-900 dark:text-white">Sanierung & Umbau</h3>
                 <p class="text-sm text-gray-600 dark:text-gray-300">Sanierungs- & Umbaumaßnahmen, Abrissarbeiten</p>
               </div>
@@ -201,7 +199,7 @@
             <div class="carousel-slide w-full flex-shrink-0 flex justify-center gap-4">
               <!-- Card 7 -->
               <div class="bg-white dark:bg-neutral-800 p-5 rounded-xl shadow text-center transition hover:shadow-lg w-full max-w-xs">
-                <img src="/images/demo7.jpg" alt="Schlüsselfertigbau" class="w-full h-48 object-cover rounded-md mb-4">
+                <img src="/images/demo7.jpg" alt="Schlüsselfertigbau" class="w-full h-48 object-cover rounded-md mb-4" loading="lazy">
                 <h3 class="text-lg font-semibold text-neutral-900 dark:text-white">Schlüsselfertigbau</h3>
                 <p class="text-sm text-gray-600 dark:text-gray-300">Schlüsselfertiges Bauen im Wohnbau</p>
               </div>
@@ -220,30 +218,30 @@
   </section>
 
   <!-- Counter Section (Separated) -->
-  <section class="bg-[var(--primary-color)] text-white py-20 w-full">
+  <section class="bg-[var(--primary-color)] text-white py-20 w-full counter-section">
     <div class="w-full px-4 sm:px-6 lg:px-8">
       <div class="grid grid-cols-2 md:grid-cols-4 gap-6 sm:gap-8 text-center">
         <div>
           <p class="text-4xl sm:text-5xl font-extrabold mb-1">
-            <span class="counter inline-block" data-count="5">0</span>+
+            <span class="counter inline-block" data-target="5">0</span>+
           </p>
           <p class="text-sm sm:text-lg font-medium">Jahre Erfahrung</p>
         </div>
         <div>
           <p class="text-4xl sm:text-5xl font-extrabold mb-1">
-            <span class="counter inline-block" data-count="20">0</span>+
+            <span class="counter inline-block" data-target="20">0</span>+
           </p>
           <p class="text-sm sm:text-lg font-medium">Fachkräfte im Team</p>
         </div>
         <div>
           <p class="text-4xl sm:text-5xl font-extrabold mb-1">
-            <span class="counter inline-block" data-count="500">0</span>+
+            <span class="counter inline-block" data-target="500">0</span>+
           </p>
           <p class="text-sm sm:text-lg font-medium">Projekte realisiert</p>
         </div>
         <div>
           <p class="text-4xl sm:text-5xl font-extrabold mb-1">
-            <span class="counter inline-block" data-count="100">0</span>%
+            <span class="counter inline-block" data-target="100">0</span>%
           </p>
           <p class="text-sm sm:text-lg font-medium">Kundenzufriedenheit</p>
         </div>
@@ -259,7 +257,7 @@
   <section class="bg-[var(--secondary-color)] text-white py-24">
     <div class="max-w-7xl mx-auto px-6 grid md:grid-cols-2 gap-12 items-center">
       <div data-aos="fade-right">
-        <img src="images/strategie.jpg" alt="Strategie bei HK Bau" class="rounded-2xl shadow-lg w-full object-cover max-h-[500px]" />
+        <img src="images/strategie.jpg" alt="Strategie bei HK Bau" class="rounded-2xl shadow-lg w-full object-cover max-h-[500px]" loading="lazy" />
       </div>
       <div data-aos="fade-left">
         <h2 class="text-4xl font-bold mb-2">Unsere Strategie</h2>
@@ -295,7 +293,7 @@
   <!-- Headline and Description -->
   <div class="text-center max-w-2xl mx-auto" data-aos="fade-up" data-aos-duration="800" data-aos-offset="200" data-aos-easing="ease-in-out">
     <h2 class="text-3xl sm:text-4xl font-bold text-gray-800 mb-4">
-      Unsere <span class="text-[var(--primary-color)]">Leistungen</span>
+      Unsere <span class="bg-neutral-900 px-2 rounded text-yellow-400 drop-shadow-md">Leistungen</span>
     </h2>
     <p class="text-lg text-gray-600">Entdecken Sie unser vielseitiges Bauangebot – von Erdbau bis Stahlbau – präzise, zuverlässig und auf höchstem Niveau.</p>
   </div>

--- a/Website/karriere.html
+++ b/Website/karriere.html
@@ -75,7 +75,7 @@
 <div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
-      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
     </div>
     <span class="text-white text-sm tracking-wide">Lädt...</span>
   </div>
@@ -106,7 +106,7 @@
                 </svg>
             </button>
         </div>
-        <div class="md:hidden hidden" id="mobile-menu">
+        <div id="mobile-menu" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                 <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
                 <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
@@ -128,12 +128,12 @@
 
     <div class="absolute inset-0 z-0 overflow-hidden">
   <img src="../images/mauerwerksbau.jpg" alt="Hero Hintergrund"
-       class="w-full h-full object-cover zoom-parallax" />
+       class="w-full h-full object-cover zoom-parallax" loading="lazy" />
   <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+  <div class="absolute inset-0 bg-black/60 z-10"></div>
 </div>
 
-
-    <div class="relative z-10 text-center hero-content" data-aos="zoom-in">
+    <div class="relative z-20 text-center hero-content" data-aos="zoom-in">
         <h1 class="text-4xl md:text-6xl font-bold mb-4">Karriere bei HK Bau</h1>
         <p class="text-lg md:text-xl max-w-2xl mx-auto">Bauen Sie Ihre Zukunft mit uns – in einem starken Team.</p>
     </div>

--- a/Website/kontakt.html
+++ b/Website/kontakt.html
@@ -77,7 +77,7 @@
  <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
-      <img src="../images/logo.png" alt="HK Bau Logo"  class="h-12 w-12 animate-spin-slower" />
+      <img src="../images/logo.png" alt="HK Bau Logo"  class="h-12 w-12 animate-spin-slower" loading="lazy" />
     </div>
     <span class="text-white text-sm tracking-wide">Lädt...</span>
   </div>
@@ -111,7 +111,7 @@
             </button>
         </div>
 
-        <div class="md:hidden hidden" id="mobile-menu">
+        <div id="mobile-menu" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                 <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
                 <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
@@ -127,11 +127,12 @@
     <section class="relative h-screen overflow-hidden flex items-center justify-center parallax leistungen-hero">
         <div class="absolute inset-0 z-0 overflow-hidden">
             <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund"
-                class="w-full h-full object-cover zoom-parallax" />
+                class="w-full h-full object-cover zoom-parallax" loading="lazy" />
             <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+            <div class="absolute inset-0 bg-black/60 z-10"></div>
         </div>
 
-        <div class="relative z-10 text-center hero-content" data-aos="zoom-in">
+        <div class="relative z-20 text-center hero-content" data-aos="zoom-in">
             <h1 class="text-4xl md:text-6xl font-bold mb-4">Kontaktieren Sie uns</h1>
             <p class="text-lg md:text-xl max-w-2xl mx-auto">Wir freuen uns auf Ihre Nachricht und Ihr Bauprojekt.</p>
         </div>
@@ -196,7 +197,7 @@
                 data-aos="fade-up" data-aos-delay="1000">
                 Nachricht senden
             </button>
-            <p id="formSuccess" class="hidden text-green-600 font-semibold text-center">Vielen Dank für Ihre Nachricht! Wir melden uns bald.</p>
+            <div id="formFeedback" class="hidden opacity-0 text-green-600 bg-green-50 p-4 rounded text-center transition-opacity"></div>
         </form>
     </section>
 </main>

--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -73,7 +73,7 @@
 <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
-      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
     </div>
     <span class="text-white text-sm tracking-wide">Lädt...</span>
   </div>
@@ -106,7 +106,7 @@
             </button>
         </div>
 
-        <div class="md:hidden hidden bg-secondary-color" id="mobile-menu">
+        <div id="mobile-menu" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 text-white">
                 <a href="index.html"
                     class="block py-2 px-3 text-base font-medium hover:bg-gray-700 rounded">Startseite</a>
@@ -129,13 +129,14 @@
 
             <div class="absolute inset-0 z-0 overflow-hidden">
                 <img src="../images/pexels-sevenstormphotography-439416.jpg" alt="Hero Hintergrund"
-                    class="w-full h-full object-cover zoom-parallax" />
-                <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" />
+                    class="w-full h-full object-cover zoom-parallax" loading="lazy" />
+                <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" loading="lazy" />
                 <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+                <div class="absolute inset-0 bg-black/60 z-10"></div>
 
             </div>
 
-            <div class="relative z-10 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
+            <div class="relative z-20 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
                 <h1 class="text-4xl md:text-6xl font-bold mb-4 drop-shadow-lg">Unsere Bauleistungen</h1>
                 <p class="text-lg md:text-xl max-w-2xl mx-auto mb-8 opacity-90">Qualität, Präzision und Erfahrung für
                     Ihre Projekte in Sindelfingen

--- a/Website/leistungen/architekten.html
+++ b/Website/leistungen/architekten.html
@@ -21,13 +21,14 @@
 
         <div class="absolute inset-0 z-0 overflow-hidden">
             <img src="../images/pexels-sevenstormphotography-439416.jpg" alt="Hero Hintergrund"
-                class="w-full h-full object-cover zoom-parallax" />
-            <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" />
+                class="w-full h-full object-cover zoom-parallax" loading="lazy" />
+            <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" loading="lazy" />
             <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+            <div class="absolute inset-0 bg-black/60 z-10"></div>
 
         </div>
 
-        <div class="relative z-10 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
+        <div class="relative z-20 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
             <h1 class="text-4xl md:text-6xl font-bold mb-4 drop-shadow-lg">Architekten</h1>
             <p class="text-lg md:text-xl max-w-2xl mx-auto mb-8 opacity-90">Qualität, Präzision und Erfahrung für
                 Ihre Projekte in Sindelfingen

--- a/Website/leistungen/investoren.html
+++ b/Website/leistungen/investoren.html
@@ -21,13 +21,14 @@
 
         <div class="absolute inset-0 z-0 overflow-hidden">
             <img src="../images/pexels-sevenstormphotography-439416.jpg" alt="Hero Hintergrund"
-                class="w-full h-full object-cover zoom-parallax" />
-            <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" />
+                class="w-full h-full object-cover zoom-parallax" loading="lazy" />
+            <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" loading="lazy" />
             <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+            <div class="absolute inset-0 bg-black/60 z-10"></div>
 
         </div>
 
-        <div class="relative z-10 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
+        <div class="relative z-20 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
             <h1 class="text-4xl md:text-6xl font-bold mb-4 drop-shadow-lg">Investoren</h1>
             <p class="text-lg md:text-xl max-w-2xl mx-auto mb-8 opacity-90">Qualität, Präzision und Erfahrung für
                 Ihre Projekte in Sindelfingen

--- a/Website/leistungen/privatkunden.html
+++ b/Website/leistungen/privatkunden.html
@@ -21,13 +21,14 @@
 
         <div class="absolute inset-0 z-0 overflow-hidden">
             <img src="../images/pexels-sevenstormphotography-439416.jpg" alt="Hero Hintergrund"
-                class="w-full h-full object-cover zoom-parallax" />
-            <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" />
+                class="w-full h-full object-cover zoom-parallax" loading="lazy" />
+            <img src="../images/hero-leistungen.jpg" alt="Hero Hintergrund" class="absolute inset-0 w-full h-full object-cover -z-10 zoom-parallax" loading="lazy" />
             <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+            <div class="absolute inset-0 bg-black/60 z-10"></div>
 
         </div>
 
-        <div class="relative z-10 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
+        <div class="relative z-20 text-center hero-content max-w-3xl text-white" data-aos="zoom-in">
             <h1 class="text-4xl md:text-6xl font-bold mb-4 drop-shadow-lg">Privatkunden</h1>
             <p class="text-lg md:text-xl max-w-2xl mx-auto mb-8 opacity-90">Qualität, Präzision und Erfahrung für
                 Ihre Projekte in Sindelfingen

--- a/Website/referenzen.html
+++ b/Website/referenzen.html
@@ -79,7 +79,7 @@
 <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
-      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
     </div>
     <span class="text-white text-sm tracking-wide">Lädt...</span>
   </div>
@@ -113,7 +113,7 @@
             </button>
         </div>
 
-        <div class="md:hidden hidden" id="mobile-menu">
+        <div id="mobile-menu" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                 <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
                 <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
@@ -131,9 +131,10 @@
         <img src="../images/pexels-kawserhamid-176342.jpg" alt="Bauprojekt"
             class="w-full h-full object-cover zoom-parallax" loading="lazy" />
         <div class="absolute inset-0 bg-gradient-to-b from-[var(--secondary-color)]/70 to-[var(--secondary-color)]/30"></div>
+        <div class="absolute inset-0 bg-black/60 z-10"></div>
     </div>
 
-    <div class="relative z-10 text-center px-6 max-w-2xl text-white hero-content" data-aos="zoom-in">
+    <div class="relative z-20 text-center px-6 max-w-2xl text-white hero-content" data-aos="zoom-in">
         <h1 class="text-4xl md:text-6xl font-bold mb-6">Einblicke in unsere Leistungen</h1>
         <p class="text-lg md:text-xl mb-10"> – von der Baugrube bis zur obersten Decke, unabhängig vom Nutzungstyp – </p>
         <a href="kontakt.html"

--- a/Website/wissen.html
+++ b/Website/wissen.html
@@ -115,7 +115,7 @@
   <div class="page-transition-overlay flex items-center justify-center">
     <div class="flex flex-col items-center space-y-4 animate-fade-in">
       <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
-        <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+        <img src="../images/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
       </div>
       <span class="text-white text-sm tracking-wide">Lädt...</span>
     </div>
@@ -142,7 +142,7 @@
         </svg>
       </button>
     </div>
-    <div class="md:hidden hidden" id="mobile-menu">
+    <div id="mobile-menu" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out">
       <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
         <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
         <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
@@ -158,7 +158,8 @@
   <!-- Hero Section -->
   <section class="relative h-[80vh] flex items-center justify-center parallax bg-cover bg-center" style="background-image: url('../images/pexels-sevomont.jpg');">
     <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
-    <div class="relative z-10 text-center text-white px-6" data-aos="zoom-in">
+    <div class="absolute inset-0 bg-black/60 z-10"></div>
+    <div class="relative z-20 text-center text-white px-6" data-aos="zoom-in">
       <h1 class="text-4xl md:text-6xl font-bold mb-4">Wissen & Aktuelles</h1>
       <p class="text-lg max-w-2xl mx-auto">News, Einblicke & Tipps rund um den Bau – direkt von HK Bau.</p>
     </div>

--- a/Website/wissen/betonieren-im-winter.html
+++ b/Website/wissen/betonieren-im-winter.html
@@ -61,11 +61,12 @@
   <!-- Hero Section -->
   <section class="relative h-[60vh] flex items-center justify-center overflow-hidden parallax">
     <div class="absolute inset-0 z-0 overflow-hidden">
-      <img src="../images/kanalbau.jpg" alt="Betonieren im Winter" class="w-full h-full object-cover zoom-parallax" />
+      <img src="../images/kanalbau.jpg" alt="Betonieren im Winter" class="w-full h-full object-cover zoom-parallax" loading="lazy" />
       <div class="absolute inset-0 bg-[var(--secondary-color)]/60"></div>
+      <div class="absolute inset-0 bg-black/60 z-10"></div>
     </div>
 
-    <div class="relative z-10 text-center text-white px-4 hero-content" data-aos="zoom-in">
+    <div class="relative z-20 text-center text-white px-4 hero-content" data-aos="zoom-in">
       <p class="text-sm uppercase tracking-widest text-[var(--primary-color)] mb-2">Wissen</p>
       <h1 class="text-4xl md:text-6xl font-bold mb-4">Betonieren im Winter</h1>
       <p class="text-lg md:text-xl text-white/80">Was Bauunternehmen in der kalten Jahreszeit beachten sollten</p>

--- a/js/app.js
+++ b/js/app.js
@@ -5,13 +5,13 @@ function initMobileMenu(menuBtnId, mobileMenuId) {
 
     if (menuBtn && mobileMenu) {
         menuBtn.addEventListener("click", () => {
-            mobileMenu.classList.toggle("hidden");
-            menuBtn.setAttribute("aria-expanded", !mobileMenu.classList.contains("hidden"));
+            const isHidden = mobileMenu.classList.toggle("translate-x-full");
+            menuBtn.setAttribute("aria-expanded", !isHidden);
         });
 
         mobileMenu.querySelectorAll("a").forEach(link => {
             link.addEventListener("click", () => {
-                mobileMenu.classList.add("hidden");
+                mobileMenu.classList.add("translate-x-full");
                 menuBtn.setAttribute("aria-expanded", "false");
             });
 
@@ -110,19 +110,23 @@ function initFormValidation(formId) {
 }
 
 // ========== Contact Form Demo Handler ============
+// Show simple feedback message after submitting the demo form
 function handleContactDemo(formId) {
     const form = document.getElementById(formId);
-    if (!form) return;
+    const feedback = document.getElementById("formFeedback");
+    if (!form || !feedback) return;
 
     form.addEventListener("submit", (e) => {
         e.preventDefault();
         form.classList.add("animate-pulse");
+        feedback.classList.add("hidden", "opacity-0");
 
         setTimeout(() => {
             form.classList.remove("animate-pulse");
             form.reset();
-            const success = document.getElementById("formSuccess");
-            if (success) success.classList.remove("hidden");
+            feedback.textContent = "Vielen Dank für Ihre Nachricht!";
+            feedback.classList.remove("hidden");
+            requestAnimationFrame(() => feedback.classList.remove("opacity-0"));
         }, 1000);
     });
 }
@@ -539,32 +543,33 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 
+// Animate counters when the section scrolls into view
 function initAnimatedCounters() {
+  const section = document.querySelector('.counter-section');
   const counters = document.querySelectorAll('.counter');
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        const counter = entry.target;
-        const target = +counter.getAttribute('data-count');
-        let count = 0;
-        const duration = 1500;
-        const step = Math.ceil(target / (duration / 16));
+  if (!section || counters.length === 0) return;
 
-        const update = () => {
-          count += step;
-          if (count >= target) {
-            counter.textContent = target;
-            observer.unobserve(counter);
-          } else {
-            counter.textContent = count;
-            requestAnimationFrame(update);
-          }
-        };
+  const animate = (counter) => {
+    const target = parseInt(counter.dataset.target, 10);
+    const duration = 2000;
+    let start = null;
 
-        requestAnimationFrame(update);
-      }
-    });
-  }, { threshold: 0.6 });
+    const step = (timestamp) => {
+      if (!start) start = timestamp;
+      const progress = Math.min((timestamp - start) / duration, 1);
+      counter.textContent = Math.floor(progress * target);
+      if (progress < 1) requestAnimationFrame(step);
+    };
 
-  counters.forEach(counter => observer.observe(counter));
+    requestAnimationFrame(step);
+  };
+
+  const observer = new IntersectionObserver((entries) => {
+    if (entries[0].isIntersecting) {
+      counters.forEach(animate);
+      observer.disconnect();
+    }
+  }, { threshold: 0.4 });
+
+  observer.observe(section);
 }


### PR DESCRIPTION
## Summary
- animate counters when visible
- darken hero sections for readability
- improve heading contrast
- slide-in mobile menu on small screens
- lazy load remaining images
- show contact form feedback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e0cdf1238832cb45fb04ce5b87f25