### PR TITLE
Add navigation backdrop and SEO updates

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -14,8 +14,7 @@
 <meta name="apple-mobile-web-app-title" content="HK Bau" />
 <link rel="manifest" href="/site.webmanifest" />
 
-  <meta name="description"
-    content="HK Bau – Ihr zuverlässiger Partner für Hoch- und Tiefbau in Stuttgart und Umgebung. Erdbau, Rohbau, Ausbau & mehr." />
+  <meta name="description" content="HK Bau – Ihr Bauunternehmen in Fellbach für Rohbau, Erdarbeiten und schlüsselfertiges Bauen." />
   <meta name="keywords"
     content="Bauunternehmen Stuttgart, Rohbau, Ausbau, HK Bau, Erdbau, Kanalbau, Sanierung, Bauprojekte, Sindelfingen" />
   <meta name="author" content="HK Bau GmbH" />
@@ -23,9 +22,9 @@
   <link rel="canonical" href="https://www.hk-bau.net/index.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="HK Bau – Hoch- und Tiefbau aus einer Hand" />
-  <meta property="og:description" content="Ihr Bauunternehmen für Stuttgart & Region. Rohbau, Sanierung, Ausbau." />
-  <meta property="og:image" content="/images/logo.png" />
+  <meta property="og:title" content="HK Bauunternehmung GmbH" />
+  <meta property="og:description" content="Zuverlässiger Partner für Rohbau, Erd- und Betonarbeiten in Stuttgart und Umgebung." />
+  <meta property="og:image" content="/images/og-preview.jpg" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://www.hk-bau.net/index.html" />
 
@@ -148,7 +147,7 @@
       </div>
 
       <!-- Carousel -->
-      <div class="relative wir-schaffen-carousel">
+      <div class="relative wir-schaffen-carousel carousel-container">
         <div class="overflow-hidden">
           <div class="carousel-wrapper flex transition-transform duration-700 ease-in-out touch-pan-x">
             <!-- Slide 1 -->
@@ -208,8 +207,8 @@
         </div>
 
         <!-- Navigation Buttons -->
-        <button class="carousel-prev-btn absolute left-4 top-1/2 -translate-y-1/2 z-10 bg-[var(--primary-color)] text-white rounded-full w-8 h-8 shadow hover:bg-[var(--primary-hover)] transition">‹</button>
-        <button class="carousel-next-btn absolute right-4 top-1/2 -translate-y-1/2 z-10 bg-[var(--primary-color)] text-white rounded-full w-8 h-8 shadow hover:bg-[var(--primary-hover)] transition">›</button>
+        <button class="carousel-prev-btn carousel-prev absolute left-4 top-1/2 -translate-y-1/2 z-10 bg-[var(--primary-color)] text-white rounded-full w-8 h-8 shadow hover:bg-[var(--primary-hover)] transition">‹</button>
+        <button class="carousel-next-btn carousel-next absolute right-4 top-1/2 -translate-y-1/2 z-10 bg-[var(--primary-color)] text-white rounded-full w-8 h-8 shadow hover:bg-[var(--primary-hover)] transition">›</button>
 
         <!-- Dots -->
         <div class="carousel-indicators flex justify-center gap-2 mt-6 sticky bottom-2 z-20 bg-white/80 dark:bg-neutral-900/80 backdrop-blur rounded-full py-2 px-4 w-fit mx-auto shadow-md"></div>
@@ -454,7 +453,7 @@
         </h2>
 
         <!-- Carousel Container -->
-        <div class="relative overflow-hidden rounded-2xl shadow-xl bg-white project-carousel">
+        <div class="relative overflow-hidden rounded-2xl shadow-xl bg-white project-carousel carousel-container">
           <div class="carousel-wrapper flex transition-transform duration-700 ease-in-out">
 
             <!-- Slide 1 -->
@@ -505,12 +504,12 @@
 
           <!-- Arrows -->
           <button
-            class="absolute top-1/2 left-4 transform -translate-y-1/2 bg-[var(--primary-color)] text-white text-xl px-4 py-2 rounded-full shadow-md hover:scale-110 transition carousel-prev-btn z-10"
+            class="absolute top-1/2 left-4 transform -translate-y-1/2 bg-[var(--primary-color)] text-white text-xl px-4 py-2 rounded-full shadow-md hover:scale-110 transition carousel-prev-btn carousel-prev z-10"
             aria-label="Zurück">
             ‹
           </button>
           <button
-            class="absolute top-1/2 right-4 transform -translate-y-1/2 bg-[var(--primary-color)] text-white text-xl px-4 py-2 rounded-full shadow-md hover:scale-110 transition carousel-next-btn z-10"
+            class="absolute top-1/2 right-4 transform -translate-y-1/2 bg-[var(--primary-color)] text-white text-xl px-4 py-2 rounded-full shadow-md hover:scale-110 transition carousel-next-btn carousel-next z-10"
             aria-label="Weiter">
             ›
           </button>
@@ -593,7 +592,7 @@
   </main>
 
  <!-- Footer -->
-<footer class="bg-secondary-color text-text-on-dark py-10 text-center">
+<footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
   <div class="space-y-4">
     <nav class="space-x-4">
       <a href="index.html">Startseite</a>
@@ -628,8 +627,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
     </svg>
   </button>
-
-
+  <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
 
 </body>
 

--- a/Website/kontakt.html
+++ b/Website/kontakt.html
@@ -8,18 +8,16 @@
 <link rel="icon" href="/images/favicon.ico" type="image/x-icon" />
 <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon" />
 
-    <meta name="description"
-        content="Nehmen Sie Kontakt auf mit HK Bau in Sindelfingen. Wir beraten Sie gern zu Ihrem Bauvorhaben." />
+    <meta name="description" content="HK Bau – Ihr Bauunternehmen in Fellbach für Rohbau, Erdarbeiten und schlüsselfertiges Bauen." />
     <meta name="keywords" content="Kontakt, Bauunternehmen, HK Bau, Bauanfrage, Angebot, Sindelfingen, Stuttgart" />
     <meta name="author" content="HK Bau GmbH" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://www.hk-bau.net/kontakt.html" />
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Kontakt – HK Bau" />
-    <meta property="og:description"
-        content="Sie möchten bauen? Kontaktieren Sie HK Bau für Ihr Projekt in Stuttgart und Umgebung." />
-    <meta property="og:image" content="/images/logo.png" />
+    <meta property="og:title" content="HK Bauunternehmung GmbH" />
+    <meta property="og:description" content="Zuverlässiger Partner für Rohbau, Erd- und Betonarbeiten in Stuttgart und Umgebung." />
+    <meta property="og:image" content="/images/og-preview.jpg" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.hk-bau.net/kontakt.html" />
 
@@ -197,7 +195,7 @@
                 data-aos="fade-up" data-aos-delay="1000">
                 Nachricht senden
             </button>
-            <div id="formFeedback" class="hidden opacity-0 text-green-600 bg-green-50 p-4 rounded text-center transition-opacity"></div>
+            <div id="form-message" class="hidden"></div>
         </form>
     </section>
 </main>
@@ -215,7 +213,7 @@
     
 
     <!-- Footer -->
-<footer class="bg-secondary-color text-text-on-dark py-10 text-center">
+<footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
   <div class="space-y-4">
     <nav class="space-x-4">
       <a href="index.html">Startseite</a>
@@ -250,6 +248,8 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
         </svg>
     </button>
+
+    <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
 
 </body>
 

--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -8,17 +8,15 @@
 <link rel="icon" href="/images/favicon.ico" type="image/x-icon" />
 <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon" />
 
-    <meta name="description"
-        content="Entdecken Sie unsere Leistungen: Erdbau, Rohbau, Kanalbau, Stahlbeton, Ausbau – alles aus einer Hand mit HK Bau." />
+    <meta name="description" content="HK Bau – Ihr Bauunternehmen in Fellbach für Rohbau, Erdarbeiten und schlüsselfertiges Bauen." />
     <meta name="keywords" content="Bauleistungen, Rohbau, Erdbau, Kanalbau, Ausbau, Bauunternehmen Stuttgart, HK Bau" />
     <meta name="author" content="HK Bau GmbH" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://www.hk-bau.net/leistungen.html" />
 
     <meta property="og:title" content="Leistungen – HK Bau" />
-    <meta property="og:description"
-        content="HK Bau bietet umfassende Leistungen im Hoch- und Tiefbau: Erdbau, Rohbau, Ausbau u.v.m." />
-    <meta property="og:image" content="/images/logo.png" />
+    <meta property="og:description" content="Unsere Bauleistungen: Rohbau, Erdarbeiten, Betonbau..." />
+    <meta property="og:image" content="/images/og-preview.jpg" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.hk-bau.net/leistungen.html" />
 
@@ -331,7 +329,7 @@
     </main>
 
    <!-- Footer -->
-<footer class="bg-secondary-color text-text-on-dark py-10 text-center">
+<footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
   <div class="space-y-4">
     <nav class="space-x-4">
       <a href="index.html">Startseite</a>
@@ -369,6 +367,7 @@
     
 
     <script src="../js/app.js" defer></script>
+    <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
 </body>
 
 </html>

--- a/Website/referenzen.html
+++ b/Website/referenzen.html
@@ -8,8 +8,7 @@
 <link rel="icon" href="/images/favicon.ico" type="image/x-icon" />
 <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon" />
 
-    <meta name="description"
-        content="Referenzen – HK Bau Projekte aus Sindelfingen & Stuttgart: Erdbau, Kanalbau, Rohbau & mehr." />
+    <meta name="description" content="HK Bau – Ihr Bauunternehmen in Fellbach für Rohbau, Erdarbeiten und schlüsselfertiges Bauen." />
     <meta name="keywords"
         content="Referenzen, Bauprojekte, HK Bau, Erdbau, Kanalbau, Stahlbetonbau, Rohbau, Stuttgart, Sindelfingen" />
     <meta name="author" content="HK Bau GmbH" />
@@ -17,10 +16,9 @@
     <link rel="canonical" href="https://www.hk-bau.net/referenzen.html" />
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Referenzen – HK Bau" />
-    <meta property="og:description"
-        content="Einblick in unsere abgeschlossenen Projekte im Hoch- und Tiefbau. Qualität, Zuverlässigkeit & Erfahrung." />
-    <meta property="og:image" content="/images/logo.png" />
+    <meta property="og:title" content="HK Bauunternehmung GmbH" />
+    <meta property="og:description" content="Zuverlässiger Partner für Rohbau, Erd- und Betonarbeiten in Stuttgart und Umgebung." />
+    <meta property="og:image" content="/images/og-preview.jpg" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.hk-bau.net/referenzen.html" />
 
@@ -385,7 +383,7 @@
 
     </main>
  <!-- Footer -->
-<footer class="bg-secondary-color text-text-on-dark py-10 text-center">
+<footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
   <div class="space-y-4">
     <nav class="space-x-4">
       <a href="index.html">Startseite</a>
@@ -419,7 +417,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
         </svg>
     </button>
-
+    <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
 
 
 <style>

--- a/Website/wissen.html
+++ b/Website/wissen.html
@@ -8,7 +8,7 @@
 <link rel="icon" href="/images/favicon.ico" type="image/x-icon" />
 <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon" />
 
-  <meta name="description" content="Wissen & News von HK Bau – Tipps, Artikel & Einblicke rund um den Bau." />
+  <meta name="description" content="HK Bau – Ihr Bauunternehmen in Fellbach für Rohbau, Erdarbeiten und schlüsselfertiges Bauen." />
   <meta name="keywords" content="Bauwissen, Bau Blog, Tipps, Bauunternehmen, HK Bau, Stuttgart, Sindelfingen" />
   <meta name="author" content="HK Bau GmbH" />
   <meta name="robots" content="index, follow" />
@@ -56,9 +56,9 @@
 </script>
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Wissen & Aktuelles – HK Bau" />
-  <meta property="og:description" content="News, Einblicke und Artikel aus der Baupraxis. Von HK Bau für Sie zusammengestellt." />
-  <meta property="og:image" content="/images/logo.png" />
+  <meta property="og:title" content="HK Bauunternehmung GmbH" />
+  <meta property="og:description" content="Zuverlässiger Partner für Rohbau, Erd- und Betonarbeiten in Stuttgart und Umgebung." />
+  <meta property="og:image" content="/images/og-preview.jpg" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://www.hk-bau.net/wissen.html" />
 
@@ -221,7 +221,7 @@
 </section>
 
  <!-- Footer -->
-<footer class="bg-secondary-color text-text-on-dark py-10 text-center">
+<footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
   <div class="space-y-4">
     <nav class="space-x-4">
       <a href="index.html">Startseite</a>
@@ -258,6 +258,7 @@
 
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="../js/app.js" defer></script>
+  <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
 </body>
 
 </html>

--- a/Website/wissen/betonieren-im-winter.html
+++ b/Website/wissen/betonieren-im-winter.html
@@ -5,7 +5,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Betonieren im Winter – HK Bau Wissen</title>
-  <meta name="description" content="Tipps und Hinweise zum Betonieren bei kalten Temperaturen." />
+  <meta name="description" content="HK Bau – Ihr Bauunternehmen in Fellbach für Rohbau, Erdarbeiten und schlüsselfertiges Bauen." />
+  <meta property="og:title" content="Betonieren im Winter" />
+  <meta property="og:description" content="Tipps und Hinweise zum Betonieren bei kalten Temperaturen." />
+  <meta property="og:image" content="/images/og-preview.jpg" />
+  <meta property="og:type" content="website" />
 
   <!-- ✅ SEO Structured Data (JSON-LD) -->
 <script type="application/ld+json">
@@ -135,7 +139,7 @@
 
 
 <!-- Footer -->
-<footer class="bg-secondary-color text-text-on-dark py-10 text-center">
+<footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
   <div class="space-y-4">
     <nav class="space-x-4">
       <a href="../index.html">Startseite</a>
@@ -150,6 +154,8 @@
     </p>
   </div>
 </footer>
+
+  <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
 
 
 </body>

--- a/js/app.js
+++ b/js/app.js
@@ -2,17 +2,28 @@
 function initMobileMenu(menuBtnId, mobileMenuId) {
     const menuBtn = document.getElementById(menuBtnId);
     const mobileMenu = document.getElementById(mobileMenuId);
+    const backdrop = document.getElementById('nav-backdrop');
 
     if (menuBtn && mobileMenu) {
         menuBtn.addEventListener("click", () => {
             const isHidden = mobileMenu.classList.toggle("translate-x-full");
             menuBtn.setAttribute("aria-expanded", !isHidden);
+            if (backdrop) backdrop.classList.toggle('hidden', isHidden);
         });
+
+        if (backdrop) {
+            backdrop.addEventListener('click', () => {
+                mobileMenu.classList.add('translate-x-full');
+                menuBtn.setAttribute('aria-expanded', 'false');
+                backdrop.classList.add('hidden');
+            });
+        }
 
         mobileMenu.querySelectorAll("a").forEach(link => {
             link.addEventListener("click", () => {
                 mobileMenu.classList.add("translate-x-full");
                 menuBtn.setAttribute("aria-expanded", "false");
+                if (backdrop) backdrop.classList.add('hidden');
             });
 
             link.addEventListener("keydown", (e) => {
@@ -110,24 +121,26 @@ function initFormValidation(formId) {
 }
 
 // ========== Contact Form Demo Handler ============
-// Show simple feedback message after submitting the demo form
+const baseMsgClass = "text-center mt-4 p-2 rounded transition-opacity duration-300";
 function handleContactDemo(formId) {
     const form = document.getElementById(formId);
-    const feedback = document.getElementById("formFeedback");
-    if (!form || !feedback) return;
+    const msg = document.getElementById('form-message');
+    if (!form || !msg) return;
 
-    form.addEventListener("submit", (e) => {
+    async function fakeSend() {
+        return new Promise(res => setTimeout(res, 500));
+    }
+
+    form.addEventListener('submit', async (e) => {
         e.preventDefault();
-        form.classList.add("animate-pulse");
-        feedback.classList.add("hidden", "opacity-0");
-
-        setTimeout(() => {
-            form.classList.remove("animate-pulse");
-            form.reset();
-            feedback.textContent = "Vielen Dank für Ihre Nachricht!";
-            feedback.classList.remove("hidden");
-            requestAnimationFrame(() => feedback.classList.remove("opacity-0"));
-        }, 1000);
+        try {
+            await fakeSend(); // replace with real fetch()
+            msg.textContent = 'Vielen Dank für Ihre Nachricht!';
+            msg.className = 'text-green-700 bg-green-100 ' + baseMsgClass;
+        } catch {
+            msg.textContent = 'Fehler – bitte versuchen Sie es erneut.';
+            msg.className = 'text-red-700 bg-red-100 ' + baseMsgClass;
+        }
     });
 }
 
@@ -509,6 +522,19 @@ document.addEventListener("DOMContentLoaded", () => {
   initServicesCarousel();
   initWirSchaffenCarousel();
   initAnimatedCounters(); // ✅ Make sure this is the correct one
+
+  document.querySelectorAll('.carousel-container').forEach(container => {
+    let startX = 0;
+    container.addEventListener('touchstart', e => {
+      startX = e.touches[0].clientX;
+    });
+    container.addEventListener('touchend', e => {
+      let endX = e.changedTouches[0].clientX;
+      let diff = endX - startX;
+      if (diff > 50) container.querySelector('.carousel-prev')?.click();
+      else if (diff < -50) container.querySelector('.carousel-next')?.click();
+    });
+  });
 
   window.addEventListener("hashchange", setActiveLink);
 


### PR DESCRIPTION
## Summary
- update mobile menu logic with backdrop
- handle form messages via JS
- add carousel swipe detection
- enhance SEO tags across pages
- add AOS fade-in to footers
- inject backdrop element site-wide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e19f0a4c0832c8c1f1ff86f9b057d