### PR TITLE
Add standalone service gallery template

### DIFF
--- a/Website/leistung-template.html
+++ b/Website/leistung-template.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Leistung Vorlage – HK Bau</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/lightgallery@2.7.1/css/lightgallery-bundle.min.css" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+  <link rel="stylesheet" href="../css/style.css" />
+  <meta name="theme-color" content="#fbbb21" />
+</head>
+<body class="font-[Inter] text-gray-800 overflow-x-hidden">
+  <header id="navbar" class="fixed top-0 left-0 w-full z-50 bg-secondary-color text-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+      <a href="index.html" class="flex items-center">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-auto rounded-full shadow" loading="lazy" />
+        <span class="font-bold ml-2">HK Bau</span>
+      </a>
+      <nav class="hidden md:flex space-x-8 font-medium">
+        <a href="index.html" class="hover:text-[var(--primary-color)]">Startseite</a>
+        <a href="leistungen.html" class="hover:text-[var(--primary-color)]">Leistungen</a>
+        <a href="kontakt.html" class="hover:text-[var(--primary-color)]">Kontakt</a>
+      </nav>
+      <button id="mobile-menu-button" class="md:hidden focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)]" aria-expanded="false" aria-controls="mobile-menu">
+        <svg class="h-6 w-6 fill-current" viewBox="0 0 24 24">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z" />
+        </svg>
+      </button>
+    </div>
+    <nav id="mobile-menu" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out">
+      <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
+        <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
+        <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
+        <a href="kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
+      </div>
+    </nav>
+  </header>
+
+  <main class="pt-16">
+    <section class="relative h-80 md:h-[500px] flex items-center justify-center overflow-hidden">
+      <img src="../images/hero-hochbau.jpg" alt="Hochbau" class="absolute inset-0 w-full h-full object-cover -z-10" />
+      <div class="absolute inset-0 bg-black/50"></div>
+      <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white">Hochbau</h1>
+    </section>
+
+    <section class="py-12 max-w-7xl mx-auto px-4">
+      <h2 class="text-3xl font-bold text-center text-secondary-color mb-8">Unsere Arbeiten im Bereich Hochbau</h2>
+      <div id="lightgallery" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4" data-aos="fade-up">
+        <a href="../images/hochbau1.jpg"><img src="../images/hochbau1.jpg" alt="Hochbau Bild 1" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau2.jpg"><img src="../images/hochbau2.jpg" alt="Hochbau Bild 2" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau3.jpg"><img src="../images/hochbau3.jpg" alt="Hochbau Bild 3" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau4.jpg"><img src="../images/hochbau4.jpg" alt="Hochbau Bild 4" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau5.jpg"><img src="../images/hochbau5.jpg" alt="Hochbau Bild 5" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau6.jpg"><img src="../images/hochbau6.jpg" alt="Hochbau Bild 6" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau7.jpg"><img src="../images/hochbau7.jpg" alt="Hochbau Bild 7" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau8.jpg"><img src="../images/hochbau8.jpg" alt="Hochbau Bild 8" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau9.jpg"><img src="../images/hochbau9.jpg" alt="Hochbau Bild 9" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau10.jpg"><img src="../images/hochbau10.jpg" alt="Hochbau Bild 10" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau11.jpg"><img src="../images/hochbau11.jpg" alt="Hochbau Bild 11" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau12.jpg"><img src="../images/hochbau12.jpg" alt="Hochbau Bild 12" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau13.jpg"><img src="../images/hochbau13.jpg" alt="Hochbau Bild 13" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau14.jpg"><img src="../images/hochbau14.jpg" alt="Hochbau Bild 14" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau15.jpg"><img src="../images/hochbau15.jpg" alt="Hochbau Bild 15" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau16.jpg"><img src="../images/hochbau16.jpg" alt="Hochbau Bild 16" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau17.jpg"><img src="../images/hochbau17.jpg" alt="Hochbau Bild 17" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau18.jpg"><img src="../images/hochbau18.jpg" alt="Hochbau Bild 18" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau19.jpg"><img src="../images/hochbau19.jpg" alt="Hochbau Bild 19" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau20.jpg"><img src="../images/hochbau20.jpg" alt="Hochbau Bild 20" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau21.jpg"><img src="../images/hochbau21.jpg" alt="Hochbau Bild 21" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau22.jpg"><img src="../images/hochbau22.jpg" alt="Hochbau Bild 22" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau23.jpg"><img src="../images/hochbau23.jpg" alt="Hochbau Bild 23" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau24.jpg"><img src="../images/hochbau24.jpg" alt="Hochbau Bild 24" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau25.jpg"><img src="../images/hochbau25.jpg" alt="Hochbau Bild 25" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau26.jpg"><img src="../images/hochbau26.jpg" alt="Hochbau Bild 26" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau27.jpg"><img src="../images/hochbau27.jpg" alt="Hochbau Bild 27" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau28.jpg"><img src="../images/hochbau28.jpg" alt="Hochbau Bild 28" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau29.jpg"><img src="../images/hochbau29.jpg" alt="Hochbau Bild 29" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau30.jpg"><img src="../images/hochbau30.jpg" alt="Hochbau Bild 30" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau31.jpg"><img src="../images/hochbau31.jpg" alt="Hochbau Bild 31" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau32.jpg"><img src="../images/hochbau32.jpg" alt="Hochbau Bild 32" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau33.jpg"><img src="../images/hochbau33.jpg" alt="Hochbau Bild 33" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau34.jpg"><img src="../images/hochbau34.jpg" alt="Hochbau Bild 34" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau35.jpg"><img src="../images/hochbau35.jpg" alt="Hochbau Bild 35" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau36.jpg"><img src="../images/hochbau36.jpg" alt="Hochbau Bild 36" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau37.jpg"><img src="../images/hochbau37.jpg" alt="Hochbau Bild 37" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau38.jpg"><img src="../images/hochbau38.jpg" alt="Hochbau Bild 38" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau39.jpg"><img src="../images/hochbau39.jpg" alt="Hochbau Bild 39" class="w-full h-auto rounded-lg shadow-md"></a>
+        <a href="../images/hochbau40.jpg"><img src="../images/hochbau40.jpg" alt="Hochbau Bild 40" class="w-full h-auto rounded-lg shadow-md"></a>
+      </div>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/lightgallery@2.7.1/lightgallery.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/lightgallery@2.7.1/plugins/zoom/lg-zoom.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/lightgallery@2.7.1/plugins/fullscreen/lg-fullscreen.umd.js"></script>
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script src="../js/app.js"></script>
+  <script>
+    AOS.init();
+    lightGallery(document.getElementById('lightgallery'), {
+      selector: 'a',
+      plugins: [lgZoom, lgFullscreen],
+      speed: 300
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `leistung-template.html` as a base for service pages
- include sticky navbar, hero image, and responsive LightGallery grid
- preload Tailwind, Font Awesome and AOS

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6874c9945b1c832cbc8d197f1dcbc8f9