### PR TITLE
Remove duplicated carousel code

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -521,42 +521,6 @@
   </div>
 </section>
 
-  <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    const container = document.querySelector("#referenzen-carousel .animate-scroll-referenzen");
-    const template = document.querySelector("#carousel-duplicate");
-    if (container && template) {
-      for (let i = 0; i < 3; i++) {
-        const clone = template.content.cloneNode(true);
-        container.appendChild(clone);
-      }
-    }
-
-    // Auto zoom logic for center element
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        const img = entry.target.querySelector('img');
-        if (entry.isIntersecting) {
-          img.classList.add('scale-[1.15]');
-        } else {
-          img.classList.remove('scale-[1.15]');
-        }
-      });
-    }, {
-      root: document.querySelector('#referenzen-carousel'),
-      threshold: 0.6
-    });
-
-    document.querySelectorAll('#referenzen-carousel .snap-center').forEach(el => {
-      observer.observe(el);
-    });
-  });
-</script>
-
-
-    <!-- Kundenarten Section -->
-    <section id="message-to-clients" class="py-24 bg-gray-50">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl sm:text-4xl font-bold text-center text-[var(--secondary-color)] mb-12" data-aos="fade-up">
           Für wen wir bauen
         </h2>

--- a/css/style.css
+++ b/css/style.css
@@ -978,11 +978,11 @@ img[src*="placeholder"] {
 
 @keyframes scroll-left {
   0% { transform: translateX(0); }
-  100% { transform: translateX(-50%); }
+  100% { transform: translateX(-33.3333%); }
 }
 
 .animate-scroll-referenzen {
-  animation: scroll-left 60s linear infinite;
+  animation: scroll-left 70s linear infinite;
   display: flex;
   width: max-content;
 }
@@ -1014,74 +1014,6 @@ img[src*="placeholder"] {
   z-index: 1;
 }
 
- @keyframes scroll-left {
-    0% { transform: translateX(0); }
-    100% { transform: translateX(-33.3333%); }
-  }
-
-  .animate-scroll-referenzen {
-    animation: scroll-left 70s linear infinite;
-    display: flex;
-  }
-
-  .hover\:paused:hover {
-    animation-play-state: paused;
-  }
-
-  .scrollbar-hide::-webkit-scrollbar {
-    display: none;
-  }
-  .scrollbar-hide {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-  
-   @keyframes scroll-left {
-    0% { transform: translateX(0); }
-    100% { transform: translateX(-33.3333%); }
-  }
-
-  .animate-scroll-referenzen {
-    animation: scroll-left 70s linear infinite;
-    display: flex;
-  }
-
-  .group-hover\:paused:hover {
-    animation-play-state: paused;
-    transition: transform 1s ease-out;
-  }
-
-  .scrollbar-hide::-webkit-scrollbar {
-    display: none;
-  }
-  .scrollbar-hide {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-
-  @keyframes scroll-left {
-    0% { transform: translateX(0); }
-    100% { transform: translateX(-33.3333%); }
-  }
-
-  .animate-scroll-referenzen {
-    animation: scroll-left 70s linear infinite;
-    display: flex;
-  }
-
-  .group-hover\:paused:hover {
-    animation-play-state: paused;
-    transition: transform 1s ease-out;
-  }
-
-  .scrollbar-hide::-webkit-scrollbar {
-    display: none;
-  }
-  .scrollbar-hide {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-
-  .carousel-image {
-    transition: transform 1s ease;
-  }
+.carousel-image {
+  transition: transform 1s ease;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -522,6 +522,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initServicesCarousel();
   initWirSchaffenCarousel();
   initAnimatedCounters(); // ✅ Make sure this is the correct one
+  initReferenzenCarousel();
 
   document.querySelectorAll('.carousel-container').forEach(container => {
     let startX = 0;
@@ -600,102 +601,69 @@ function initAnimatedCounters() {
   observer.observe(section);
 }
 
-
-document.addEventListener("DOMContentLoaded", () => {
-  const referenzenCarousel = document.getElementById('referenzen-carousel');
-  if (!referenzenCarousel) return;
+// Initialize the scrolling references carousel
+function initReferenzenCarousel() {
+  const carousel = document.getElementById('referenzen-carousel');
+  if (!carousel) return;
 
   let scrollAmount = 0;
   let isHovered = false;
 
-  referenzenCarousel.addEventListener("mouseenter", () => isHovered = true);
-  referenzenCarousel.addEventListener("mouseleave", () => isHovered = false);
+  carousel.addEventListener('mouseenter', () => (isHovered = true));
+  carousel.addEventListener('mouseleave', () => (isHovered = false));
 
-  function autoScrollReferenzen() {
+  function autoScroll() {
     if (isHovered) return;
-
-    const slideWidth = referenzenCarousel.children[0].offsetWidth + 24; // slide + spacing
+    const slideWidth = carousel.children[0].offsetWidth + 24;
     scrollAmount += slideWidth;
-
-    if (scrollAmount >= referenzenCarousel.scrollWidth - referenzenCarousel.clientWidth) {
+    if (scrollAmount >= carousel.scrollWidth - carousel.clientWidth) {
       scrollAmount = 0;
     }
-
-    referenzenCarousel.scrollTo({
-      left: scrollAmount,
-      behavior: 'smooth'
-    });
+    carousel.scrollTo({ left: scrollAmount, behavior: 'smooth' });
   }
 
-  setInterval(autoScrollReferenzen, 3500);
-});
+  setInterval(autoScroll, 3500);
 
-
- const carousel = document.getElementById('referenzen-carousel');
   const track = carousel.querySelector('.flex');
   const images = track.querySelectorAll('img');
 
   function updateCenterZoom() {
     const carouselRect = carousel.getBoundingClientRect();
     const centerX = carouselRect.left + carouselRect.width / 2;
-
     let closestImg = null;
     let closestDistance = Infinity;
-
     images.forEach(img => {
       const imgRect = img.getBoundingClientRect();
       const imgCenter = imgRect.left + imgRect.width / 2;
       const distance = Math.abs(centerX - imgCenter);
-
       if (distance < closestDistance) {
         closestDistance = distance;
         closestImg = img;
       }
     });
-
     images.forEach(img => img.classList.remove('center-zoom'));
     if (closestImg) closestImg.classList.add('center-zoom');
   }
 
   setInterval(updateCenterZoom, 300);
 
-   document.addEventListener("DOMContentLoaded", () => {
-    const container = document.querySelector("#referenzen-carousel .animate-scroll-referenzen");
-    const template = document.querySelector("#carousel-duplicate");
-    if (container && template) {
-      // Clone the template twice for smooth looping
-      for (let i = 0; i < 3; i++) {
-        const clone = template.content.cloneNode(true);
-        container.appendChild(clone);
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      const img = entry.target.querySelector('img');
+      if (entry.isIntersecting) {
+        img.classList.add('scale-110');
+      } else {
+        img.classList.remove('scale-110');
       }
-    }
+    });
+  }, {
+    root: carousel,
+    threshold: 0.6
   });
 
-   document.addEventListener("DOMContentLoaded", () => {
-    const container = document.querySelector("#referenzen-carousel .animate-scroll-referenzen");
-    const template = document.querySelector("#carousel-duplicate");
-    if (container && template) {
-      for (let i = 0; i < 3; i++) {
-        const clone = template.content.cloneNode(true);
-        container.appendChild(clone);
-      }
-    }
-
-    // Auto zoom logic for center element
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.querySelector('img').classList.add('scale-110');
-        } else {
-          entry.target.querySelector('img').classList.remove('scale-110');
-        }
-      });
-    }, {
-      root: document.querySelector('#referenzen-carousel'),
-      threshold: 0.6
-    });
-
-    document.querySelectorAll('#referenzen-carousel .snap-center').forEach(el => {
-      observer.observe(el);
-    });
+  carousel.querySelectorAll('.snap-center').forEach(el => {
+    observer.observe(el);
   });
+}
+
+


### PR DESCRIPTION
## Summary
- consolidate carousel CSS and remove repeated keyframes
- remove inline script from `index.html`
- collapse duplicate DOMContentLoaded handlers into `initReferenzenCarousel()`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687601e04750832c94d63ed20d9c3246