### PR TITLE
Enable touch dragging for Referenzen carousel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -608,12 +608,32 @@ function initReferenzenCarousel() {
 
   let scrollAmount = 0;
   let isHovered = false;
+  let isDragging = false;
+  let startX = 0;
+  let startScroll = 0;
 
   carousel.addEventListener('mouseenter', () => (isHovered = true));
   carousel.addEventListener('mouseleave', () => (isHovered = false));
 
+  carousel.addEventListener('touchstart', (e) => {
+    isDragging = true;
+    startX = e.touches[0].clientX;
+    startScroll = carousel.scrollLeft;
+  });
+
+  carousel.addEventListener('touchmove', (e) => {
+    if (!isDragging) return;
+    const deltaX = startX - e.touches[0].clientX;
+    carousel.scrollLeft = startScroll + deltaX;
+  });
+
+  carousel.addEventListener('touchend', () => {
+    isDragging = false;
+    scrollAmount = carousel.scrollLeft;
+  });
+
   function autoScroll() {
-    if (isHovered) return;
+    if (isHovered || isDragging) return;
     const slideWidth = carousel.children[0].offsetWidth + 24;
     scrollAmount += slideWidth;
     if (scrollAmount >= carousel.scrollWidth - carousel.clientWidth) {


### PR DESCRIPTION
## Summary
- allow manual dragging on the Referenzen carousel by tracking touch start/move/end
- pause auto-scroll while dragging and resume after release

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68760c3715b4832cb2129ee5e181806e