### PR TITLE
Fix carousel scroll conflicts

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -453,7 +453,7 @@
 
     <!-- Continuous Scrolling Carousel -->
     <div class="overflow-hidden scrollbar-hide touch-pan-x group" id="referenzen-carousel">
-      <div class="flex gap-8 w-max px-4 sm:px-6 lg:px-8 transition-transform duration-700 ease-linear group-hover:paused animate-scroll-referenzen" style="animation: scroll-left 70s linear infinite;">
+      <div class="flex gap-8 w-max px-4 sm:px-6 lg:px-8 transition-transform duration-700 ease-linear">
         <!-- Images -->
         <!-- These are directly included now -->
         <div class="relative w-96 h-60 snap-center">

--- a/css/style.css
+++ b/css/style.css
@@ -976,20 +976,6 @@ img[src*="placeholder"] {
 }
 
 
-@keyframes scroll-left {
-  0% { transform: translateX(0); }
-  100% { transform: translateX(-33.3333%); }
-}
-
-.animate-scroll-referenzen {
-  animation: scroll-left 70s linear infinite;
-  display: flex;
-  width: max-content;
-}
-
-.hover\:paused:hover {
-  animation-play-state: paused;
-}
 
 /* Hide scrollbar */
 .scrollbar-hide::-webkit-scrollbar {

--- a/js/app.js
+++ b/js/app.js
@@ -606,6 +606,9 @@ function initReferenzenCarousel() {
   const carousel = document.getElementById('referenzen-carousel');
   if (!carousel) return;
 
+  const track = carousel.querySelector('.flex');
+  const images = track.querySelectorAll('img');
+
   let scrollAmount = 0;
   let isHovered = false;
 
@@ -614,18 +617,16 @@ function initReferenzenCarousel() {
 
   function autoScroll() {
     if (isHovered) return;
-    const slideWidth = carousel.children[0].offsetWidth + 24;
+    const gap = parseInt(getComputedStyle(track).gap) || 0;
+    const slideWidth = track.children[0].offsetWidth + gap;
     scrollAmount += slideWidth;
-    if (scrollAmount >= carousel.scrollWidth - carousel.clientWidth) {
+    if (scrollAmount >= track.scrollWidth - carousel.clientWidth) {
       scrollAmount = 0;
     }
     carousel.scrollTo({ left: scrollAmount, behavior: 'smooth' });
   }
 
   setInterval(autoScroll, 3500);
-
-  const track = carousel.querySelector('.flex');
-  const images = track.querySelectorAll('img');
 
   function updateCenterZoom() {
     const carouselRect = carousel.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- remove CSS keyframe animation for the references carousel
- keep JS-driven auto scrolling and compute slide width correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68760c4b7d18832ca101c9f5a6edaadc