### PR TITLE
Fix center-zoom selector

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1016,10 +1016,10 @@ img[src*="placeholder"] {
 }
 
 /* Center image zoom effect */
-#referenzen-carousel .flex > img {
+#referenzen-carousel .flex img {
   transition: transform 0.6s ease-in-out;
 }
-#referenzen-carousel .flex > img.center-zoom {
+#referenzen-carousel .flex img.center-zoom {
   transform: scale(1.15);
   transition: transform 0.6s ease-in-out;
   z-index: 1;


### PR DESCRIPTION
## Summary
- adjust carousel image selectors to account for wrapper elements

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68761b173b6c832c9dbb0d0767a1f431