### PR TITLE
Refactor referenzen carousel scrolling

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -454,7 +454,7 @@
     <!-- Continuous Scrolling Carousel -->
     <div class="overflow-hidden scrollbar-hide touch-pan-x group" id="referenzen-carousel">
 
-      <div class="flex gap-8 w-max px-4 sm:px-6 lg:px-8 transition-transform duration-700 ease-linear animate-scroll-referenzen">
+      <div class="flex gap-8 w-max px-4 sm:px-6 lg:px-8 transition-transform duration-700 ease-linear">
 
         <!-- Images -->
         <!-- These are directly included now -->

--- a/css/style.css
+++ b/css/style.css
@@ -664,9 +664,6 @@ img[src*="placeholder"] {
   background: none !important;
 }
 
-
-
-
 .carousel-slide {
     display: flex;
     align-items: center;
@@ -974,32 +971,6 @@ img[src*="placeholder"] {
 .hero-section {
   padding-top: 4rem; /* match navbar height */
 }
-
-
-@keyframes scroll-left {
-  0% {
-    transform: translateX(0);
-  }
-  100% {
-    transform: translateX(-33.3333%);
-  }
-}
-
-.animate-scroll-referenzen {
-  --scroll-speed: 70s;
-  animation-name: scroll-left;
-  animation-duration: var(--scroll-speed);
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
-  display: flex;
-  width: max-content;
-  transition: animation-duration 0.5s ease-out;
-}
-
-#referenzen-carousel:hover .animate-scroll-referenzen {
-  --scroll-speed: 140s;
-}
-
 
 /* Hide scrollbar */
 .scrollbar-hide::-webkit-scrollbar {

--- a/js/app.js
+++ b/js/app.js
@@ -607,9 +607,10 @@ function initReferenzenCarousel() {
   if (!carousel) return;
 
   const track = carousel.querySelector('.flex');
-  const images = track.querySelectorAll('img');
+  const slides = Array.from(track.children);
+  slides.forEach(slide => track.appendChild(slide.cloneNode(true)));
 
-  let scrollAmount = 0;
+  const images = track.querySelectorAll('img');
   let isHovered = false;
   let isDragging = false;
   let startX = 0;
@@ -632,22 +633,19 @@ function initReferenzenCarousel() {
 
   carousel.addEventListener('touchend', () => {
     isDragging = false;
-    scrollAmount = carousel.scrollLeft;
   });
 
-  function autoScroll() {
-if (isHovered || isDragging) return;
-const gap = parseInt(getComputedStyle(track).gap) || 24;
-const slideWidth = track.children[0].offsetWidth + gap;
-
-    scrollAmount += slideWidth;
-    if (scrollAmount >= track.scrollWidth - carousel.clientWidth) {
-      scrollAmount = 0;
+  const speed = 0.4;
+  function step() {
+    if (!isHovered && !isDragging) {
+      carousel.scrollLeft += speed;
+      if (carousel.scrollLeft >= track.scrollWidth / 2) {
+        carousel.scrollLeft -= track.scrollWidth / 2;
+      }
     }
-    carousel.scrollTo({ left: scrollAmount, behavior: 'smooth' });
+    requestAnimationFrame(step);
   }
-
-  setInterval(autoScroll, 3500);
+  requestAnimationFrame(step);
 
   function updateCenterZoom() {
     const carouselRect = carousel.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- remove unused `animate-scroll-referenzen` class and styles
- implement continuous scrolling via JS in `initReferenzenCarousel`
- clone slides for seamless loop

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68761b195d28832c9a61dc281c6e0e1b