### PR TITLE
Use RAF for carousel zoom when visible

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -667,7 +667,37 @@ const slideWidth = track.children[0].offsetWidth + gap;
     if (closestImg) closestImg.classList.add('center-zoom');
   }
 
-  setInterval(updateCenterZoom, 300);
+  let zoomRafId = null;
+
+  function zoomLoop() {
+    updateCenterZoom();
+    zoomRafId = requestAnimationFrame(zoomLoop);
+  }
+
+  function startZoomLoop() {
+    if (zoomRafId === null) {
+      zoomLoop();
+    }
+  }
+
+  function stopZoomLoop() {
+    if (zoomRafId !== null) {
+      cancelAnimationFrame(zoomRafId);
+      zoomRafId = null;
+    }
+  }
+
+  const visibilityObserver = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        startZoomLoop();
+      } else {
+        stopZoomLoop();
+      }
+    });
+  }, { threshold: 0 });
+
+  visibilityObserver.observe(carousel);
 
   const observer = new IntersectionObserver((entries) => {
     entries.forEach(entry => {


### PR DESCRIPTION
## Summary
- refactor center zoom logic to run with `requestAnimationFrame`
- activate the loop only while the carousel is visible using `IntersectionObserver`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68761b198e38832c8a0dc0e9201b2e91