### PR TITLE
Fix gradient overlay for small screens

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -448,8 +448,8 @@
 
   <div class="relative overflow-hidden">
     <!-- Gradient Fade Edges with soft yellow on both sides -->
-    <div class="absolute left-0 top-0 bottom-0 w-12 bg-gradient-to-r from-[#fbb034] to-transparent z-10 pointer-events-none"></div>
-    <div class="absolute right-0 top-0 bottom-0 w-12 bg-gradient-to-l from-[#fbb034] to-transparent z-10 pointer-events-none"></div>
+    <div class="absolute left-0 top-0 bottom-0 w-6 sm:w-12 bg-gradient-to-r from-[#fbb034] to-transparent z-10 pointer-events-none"></div>
+    <div class="absolute right-0 top-0 bottom-0 w-6 sm:w-12 bg-gradient-to-l from-[#fbb034] to-transparent z-10 pointer-events-none"></div>
 
     <!-- Continuous Scrolling Carousel -->
     <div class="overflow-hidden scrollbar-hide touch-pan-x group" id="referenzen-carousel">


### PR DESCRIPTION
## Summary
- adjust the gradient overlay widths for the project carousel to scale better on small devices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68761b1b0bbc832c9b4960ac209a7722