### PR TITLE
Fix referenzen carousel speed control

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -610,8 +610,6 @@ function initReferenzenCarousel() {
   const slides = Array.from(track.children);
   slides.forEach(slide => track.appendChild(slide.cloneNode(true)));
   const images = track.querySelectorAll('img');
-  let scrollAmount = 0;
-  let isHovered = false;
 
   let isDragging = false;
   let startX = 0;
@@ -654,11 +652,9 @@ function initReferenzenCarousel() {
     isDragging = false;
   });
 
-  const speed = 0.4;
-
   function autoScrollStep() {
-    if (!isHovered && !isDragging) {
-      carousel.scrollLeft += speed;
+    if (!isDragging) {
+      carousel.scrollLeft += currentSpeed;
       if (carousel.scrollLeft >= track.scrollWidth / 2) {
         carousel.scrollLeft -= track.scrollWidth / 2;
       }


### PR DESCRIPTION
## Summary
- refine the Referenzen carousel to rely on `currentSpeed`
- remove unused variables

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687621a665f4832c84fe0cd08cbb4ce8