### PR TITLE
Fix carousels spacing and speed

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -454,7 +454,7 @@
     <!-- Continuous Scrolling Carousel -->
     <div class="overflow-hidden scrollbar-hide touch-pan-x group" id="referenzen-carousel">
 
-      <div class="flex gap-4 w-max px-4 sm:px-6 lg:px-8 transition-transform duration-700 ease-linear">
+      <div class="flex gap-6 w-max px-4 sm:px-6 lg:px-8 transition-transform duration-700 ease-linear">
 
         <!-- Images -->
         <!-- These are directly included now -->

--- a/js/app.js
+++ b/js/app.js
@@ -614,7 +614,7 @@ function initReferenzenCarousel() {
   let isDragging = false;
   let startX = 0;
   let startScroll = 0;
-  const defaultSpeed = 0.5; // slower pixels per frame
+  const defaultSpeed = 0.4; // slightly slower pixels per frame
   let currentSpeed = defaultSpeed;
 
   function slowDown() {


### PR DESCRIPTION
## Summary
- restore gap between cards in the *Wir schaffen* carousel
- fine-tune speed for the *Unsere Projekte* carousel

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68763645a704832caf5d4e5e58069fa9