### PR TITLE
Update referenzen carousel speed

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -615,7 +615,8 @@ function initReferenzenCarousel() {
   let startX = 0;
   let startScroll = 0;
 
-  const defaultSpeed = 0.3; // slower pixels per frame
+  // Increased default scrolling speed for a snappier carousel
+  const defaultSpeed = 1.0; // pixels per frame
 
   let currentSpeed = defaultSpeed;
 


### PR DESCRIPTION
## Summary
- bump default carousel scroll speed in `initReferenzenCarousel`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68763cb7e5d4832cb441f056e7c35ec0