### PR TITLE
Add data-speed control for references carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Professionelle Website für die Baufirma HK Bau – gebaut mit HTML, Tailwind CS
 - Lazy Loading für Bilder
 - Slide-in Mobile Navigation
 - Animierte Counter
+- Referenzen-Karussell mit anpassbarem Tempo 
+  über das `data-speed`-Attribut am Element `#referenzen-carousel`
 
 ## Projektstruktur
 /Website/ (enthält alle HTML-Dateien)

--- a/js/app.js
+++ b/js/app.js
@@ -615,8 +615,10 @@ function initReferenzenCarousel() {
   let startX = 0;
   let startScroll = 0;
 
-  // Increased default scrolling speed for a snappier carousel
-  const defaultSpeed = 1.0; // pixels per frame
+  // Determine default scrolling speed from data attribute
+  // Example: <div id="referenzen-carousel" data-speed="1.5">
+  const attrSpeed = parseFloat(carousel.dataset.speed);
+  const defaultSpeed = isNaN(attrSpeed) ? 1.0 : attrSpeed; // pixels per frame
 
   let currentSpeed = defaultSpeed;
 


### PR DESCRIPTION
## Summary
- allow `initReferenzenCarousel` to read a `data-speed` attribute from `#referenzen-carousel`
- document carousel speed attribute in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68763eceff4c832c987b3054297ec79c