### PR TITLE
Fix duplicate slides in references carousel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -604,7 +604,8 @@ function initAnimatedCounters() {
 // Initialize the scrolling references carousel
 function initReferenzenCarousel() {
   const carousel = document.getElementById('referenzen-carousel');
-  if (!carousel) return;
+  if (!carousel || carousel.dataset.initialized) return;
+  carousel.dataset.initialized = 'true';
 
   const track = carousel.querySelector('.flex');
   const slides = Array.from(track.children);


### PR DESCRIPTION
## Summary
- prevent initializing the references carousel more than once

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876403502a0832ca5fa3f8a4d2dcf7f