### PR TITLE
Fix AOS init crash

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -507,7 +507,9 @@ function initWirSchaffenCarousel() {
 
 // ========== DOMContentLoaded Bootstrap ============
 document.addEventListener("DOMContentLoaded", () => {
-  AOS.init({ once: true, duration: 800 });
+  if (window.AOS) {
+    AOS.init({ once: true, duration: 800 });
+  }
 
   initMobileMenu("mobile-menu-button", "mobile-menu");
   initStickyHeader("navbar");


### PR DESCRIPTION
## Summary
- guard `AOS.init` so missing library doesn't stop DOMContentLoaded code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876417afd38832c8a4e6e27b04d685d