### PR TITLE
Fix carousel default speed logic

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -621,7 +621,7 @@ function initReferenzenCarousel() {
   // Determine default scrolling speed from data attribute
   // Example: <div id="referenzen-carousel" data-speed="1.5">
   const attrSpeed = parseFloat(carousel.dataset.speed);
-  const defaultSpeed = isNaN(attrSpeed) ? 1.0 : attrSpeed; // pixels per frame
+  const defaultSpeed = !isNaN(attrSpeed) && attrSpeed > 0 ? attrSpeed : 1.0; // pixels per frame
 
   let currentSpeed = defaultSpeed;
 


### PR DESCRIPTION
## Summary
- ensure `initReferenzenCarousel` never uses a zero/negative `defaultSpeed`

## Testing
- `node - <<'NODE'
const attrSpeedValues = [undefined, null, '', 'abc', '0', 0, -1, '2', 3];
attrSpeedValues.forEach(val => {
  const dataset = { speed: val };
  const attrSpeed = parseFloat(dataset.speed);
  const defaultSpeed = !isNaN(attrSpeed) && attrSpeed > 0 ? attrSpeed : 1.0;
  console.log(val, '->', defaultSpeed);
});
NODE`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68764fa7dcc4832c907fbecd69a728bc