### PR TITLE
Fix hover handling in Referenzen carousel

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -458,65 +458,65 @@
 
         <!-- Images -->
         <!-- These are directly included now -->
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/1.2 Wohnhäuser in Filderstadt-Plattenhardt.JPG" alt="Wohnhäuser in Filderstadt-Plattenhardt" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">2 Wohnhäuser in Filderstadt-Plattenhardt</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">2 Wohnhäuser in Filderstadt-Plattenhardt</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/2. Neubau MFH in Waibingen.JPG" alt="Neubau MFH in Waibingen" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2"> Neubau MFH in Waibingen</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2"> Neubau MFH in Waibingen</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/3. Neubau MFH in Waldenbuch.JPG" alt="Neubau MFH in Waldenbuch" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Waldenbuch</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Waldenbuch</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/4.Neubau MFH mit 3 WE in Remshalden.JPG" alt="Neubau MFH in Remshalden" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Remshalden</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Remshalden</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/5.Neubau MFH mit 3 WE in Remshalden.JPG" alt="Neubau MFH in Remshalden 2" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Remshalden</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Remshalden</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/6.Neubau MFH mit 5 WE in Aichwald.jpeg" alt="Neubau MFH in Aichwald" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Aichwald</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Aichwald</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/7.Neubau MFH mit 5 WE in Weinstadt.JPG" alt="Neubau MFH in Weinstadt" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Weinstadt</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Weinstadt</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/8.Neubau MFH mit 5 WE in Weinstadt.JPG" alt="Neubau MFH in Weinstadt 2" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Weinstadt 2</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Weinstadt 2</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/9.Neubau MFH mit 8 WE und TG in Sindelfingen.JPG" alt="Neubau MFH in Sindelfingen" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Sindelfingen</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Sindelfingen</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/10.Neubau MFH mit 8 WE und TG in Sindelfingen.JPG" alt="Neubau MFH in Sindelfingen 2" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Sindelfingen</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Sindelfingen</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/11.Neubau MFH mit 14 WE und TG in Neckartailfingen.JPG" alt="Neubau MFH in Neckartailfingen" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Neckartailfingen</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Neckartailfingen</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/12.Neubau MFH mit 18 WE und TG in Winnenden.JPG" alt="Neubau MFH in Winnenden" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Winnenden</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Winnenden</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/13.Neubau MFH mit 18 WE und TG in Winnenden.JPG" alt="Neubau MFH in Winnenden 2" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Winnenden</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Winnenden</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/14.Neubau von 3 Wohnhäuser in Uhingen.JPG" alt="Neubau Wohnhäuser in Uhingen" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau Wohnhäuser in Uhingen</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau Wohnhäuser in Uhingen</div>
         </div>
-        <div class="relative w-[26rem] h-[17rem] snap-center">
+        <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
           <img src="/images/projekten/15.Neubau von 3 Wohnhäuser in Uhingen.JPG" alt="Neubau Wohnhäuser in Uhingen 2" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700" />
-          <div class="absolute bottom-0 left-0 right-0 bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau Wohnhäuser in Uhingen</div>
+          <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau Wohnhäuser in Uhingen</div>
         </div>
       </div>
     </div>

--- a/css/style.css
+++ b/css/style.css
@@ -993,7 +993,7 @@ img[src*="placeholder"] {
 
 #referenzen-track {
   display: flex;
-  gap: 2rem; /* Or use Tailwind: gap-8 */
+  gap: 2.5rem; /* Increased spacing between slides */
   width: max-content;
   will-change: transform;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -613,10 +613,11 @@ function initReferenzenCarousel() {
   const slides = Array.from(track.children);
   slides.forEach(slide => track.appendChild(slide.cloneNode(true)));
   const images = track.querySelectorAll('img');
-  
+
   let isDragging = false;
   let startX = 0;
   let startScroll = 0;
+  let isHovered = false;
 
   // Determine default scrolling speed from data attribute
   // Example: <div id="referenzen-carousel" data-speed="1.5">
@@ -641,8 +642,15 @@ function initReferenzenCarousel() {
     }
   }
 
-  carousel.addEventListener('mouseenter', slowDown);
-  carousel.addEventListener('mouseleave', speedUp);
+  carousel.addEventListener('mouseenter', () => {
+    isHovered = true;
+    slowDown();
+  });
+
+  carousel.addEventListener('mouseleave', () => {
+    isHovered = false;
+    speedUp();
+  });
 
   carousel.addEventListener('touchstart', (e) => {
     isDragging = true;


### PR DESCRIPTION
## Summary
- track when the Referenzen carousel is hovered
- connect hover handling with slowDown and speedUp functions
- widen Referenzen carousel captions to match each image
- increase spacing between carousel slides

## Testing
- `node -c js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68774493da88832cb8bff4927ab5093e