### PR TITLE
Fix overlay transition id and logic

### DIFF
--- a/Website/datenschutzerklaerung.html
+++ b/Website/datenschutzerklaerung.html
@@ -70,7 +70,7 @@
 
 
 <body class="font-[Inter] bg-gray-100 text-gray-900 impressum-page overflow-x-hidden">
-<div class="page-transition-overlay flex items-center justify-center">
+<div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
       <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />

--- a/Website/impressum.html
+++ b/Website/impressum.html
@@ -69,7 +69,7 @@
 
 
 <body class="font-[Inter] bg-gray-100 text-gray-900 impressum-page overflow-x-hidden">
-<div class="page-transition-overlay flex items-center justify-center">
+<div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
       <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />

--- a/Website/index.html
+++ b/Website/index.html
@@ -79,7 +79,7 @@
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="../js/app.js" defer></script>
 
-  <div class="page-transition-overlay flex items-center justify-center">
+  <div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
     <div class="flex flex-col items-center space-y-4 animate-fade-in">
       <div
         class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">

--- a/Website/kontakt.html
+++ b/Website/kontakt.html
@@ -72,7 +72,7 @@
 
 <body class="font-[Inter] overflow-x-hidden">
 
- <div class="page-transition-overlay flex items-center justify-center">
+ <div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
       <img src="../images/icon/logo.png" alt="HK Bau Logo"  class="h-12 w-12 animate-spin-slower" loading="lazy" />

--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -68,7 +68,7 @@
 </head>
 
 <body class="font-[Inter] text-gray-800 overflow-x-hidden">
-<div class="page-transition-overlay flex items-center justify-center">
+<div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
       <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />

--- a/Website/referenzen.html
+++ b/Website/referenzen.html
@@ -74,7 +74,7 @@
 
 <body class="font-[Inter] overflow-x-hidden">
 
-<div class="page-transition-overlay flex items-center justify-center">
+<div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
       <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />

--- a/Website/wissen.html
+++ b/Website/wissen.html
@@ -112,7 +112,7 @@
 <body class="font-[Inter] overflow-x-hidden">
 
   <!-- Page Transition Overlay -->
-  <div class="page-transition-overlay flex items-center justify-center">
+  <div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
     <div class="flex flex-col items-center space-y-4 animate-fade-in">
       <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
         <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />

--- a/js/app.js
+++ b/js/app.js
@@ -177,11 +177,11 @@ function setupPageTransitions() {
     }
 
     if (sessionStorage.getItem("isTransitioning") === "true") {
-        overlay.classList.remove("is-wiping-in");
-        overlay.classList.add("is-wiping-out");
+        overlay.classList.remove("is-fading-in");
+        overlay.classList.add("is-fading-out");
 
         overlay.addEventListener("animationend", function handler() {
-            overlay.classList.remove("is-wiping-out");
+            overlay.classList.remove("is-fading-out");
             Object.assign(overlay.style, {
                 opacity: "0",
                 visibility: "hidden",
@@ -214,8 +214,8 @@ function setupPageTransitions() {
                     visibility: "visible",
                     pointerEvents: "auto"
                 });
-                overlay.classList.remove("is-wiping-out");
-                overlay.classList.add("is-wiping-in");
+                overlay.classList.remove("is-fading-out");
+        overlay.classList.add("is-fading-in");
 
                 sessionStorage.setItem("isTransitioning", "true");
                 setTimeout(() => {
@@ -224,6 +224,7 @@ function setupPageTransitions() {
             });
         }
     });
+    overlay.dataset.listenersAdded = 'true';
 }
 
 // ========== Project Carousel (Autoplay, Swipe, Indicators) ============
@@ -545,8 +546,8 @@ document.addEventListener("DOMContentLoaded", () => {
     el.textContent = new Date().getFullYear();
   });
 
-  const overlay = document.querySelector(".page-transition-overlay");
-  if (overlay) {
+  const overlay = document.getElementById("pageTransitionOverlay");
+  if (overlay && !overlay.dataset.listenersAdded) {
     const links = document.querySelectorAll("a[href]:not(.glightbox)");
     links.forEach(link => {
       const href = link.getAttribute("href");
@@ -568,6 +569,7 @@ document.addEventListener("DOMContentLoaded", () => {
         });
       });
     });
+    overlay.dataset.listenersAdded = 'true';
   }
 });
 


### PR DESCRIPTION
## Summary
- reuse a single overlay element by giving all pages `id="pageTransitionOverlay"`
- update page transition code to use the same fading classes
- guard against duplicate overlay listeners

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68775ad0255c832c9c43c329b0220735