### PR TITLE
Make detailed service sections link to reference pages

### DIFF
--- a/Referenzen/mauerwerksbau.html
+++ b/Referenzen/mauerwerksbau.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Recommended favicon links -->
+  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <meta name="apple-mobile-web-app-title" content="HK Bau" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <title>Mauerwerksbau Projekte</title>
+  <meta name="description" content="Referenzen und Projektbeispiele im Bereich Mauerwerksbau von HK Bau GmbH in Stuttgart und Umgebung" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css" />
+  <link rel="stylesheet" href="../css/style.css" />
+
+
+<!-- Open Graph / Facebook -->
+<meta property="og:title" content="Mauerwerksbau Projekte | HK Bau GmbH" />
+<meta property="og:description" content="Einblicke in unsere abgeschlossenen Mauerwerksbau-Projekte." />
+<meta property="og:image" content="https://hkbau.de/images/mauerwerksbau.jpg" />
+<meta property="og:url" content="https://hkbau.de/referenzen/mauerwerksbau.html" />
+
+<!-- Twitter Card -->
+<meta name="twitter:title" content="Mauerwerksbau Projekte | HK Bau GmbH" />
+<meta name="twitter:description" content="Mauerwerksbauarbeiten aus unserer Referenzgalerie – HK Bau GmbH." />
+<meta name="twitter:image" content="https://hkbau.de/images/mauerwerksbau.jpg" />
+<meta name="twitter:card" content="summary_large_image" />
+
+
+</head>
+<body class="font-[Inter] overflow-x-hidden">
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+  <script src="../js/app.js" defer></script>
+  <div class="page-transition-overlay flex items-center justify-center">
+    <div class="flex flex-col items-center space-y-4 animate-fade-in">
+      <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
+      </div>
+      <span class="text-white text-sm tracking-wide">Lädt...</span>
+    </div>
+  </div>
+
+
+<header class="bg-transparent fixed top-0 left-0 w-full z-50 transition duration-300" id="navbar">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+    <div class="logo-container">
+      <a href="../index.html" class="flex items-center relative z-20">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow" loading="lazy" />
+        <span class="text-white font-bold ml-2">HK Bau</span>
+      </a>
+    </div>
+    <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium text-white">
+      <a href="../index.html" class="hover:underline">Startseite</a>
+      <a href="../leistungen.html" class="hover:underline">Leistungen</a>
+      <a href="../referenzen.html" class="hover:underline">Referenzen</a>
+      <a href="../wissen.html" class="hover:underline">Wissen</a>
+      <a href="../karriere.html" class="hover:underline">Karriere</a>
+      <a href="../kontakt.html" class="hover:underline">Kontakt</a>
+    </nav>
+    <button id="mobile-menu-button" class="md:hidden focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)]" aria-expanded="false" aria-controls="mobile-menu">
+      <svg class="h-6 w-6 fill-current text-white" viewBox="0 0 24 24">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Mobile menu -->
+  <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out z-40">
+    <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
+      <a href="../index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
+      <a href="../leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
+      <a href="../referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
+      <a href="../wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <a href="../karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
+      <a href="../kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
+    </div>
+  </nav>
+</header>
+
+
+
+
+  <main>
+  <section class="relative h-[100vh] md:h-[600px] flex items-center justify-center overflow-hidden">
+    <img src="../images/mauerwerksbau.jpg" alt="Mauerwerksbau" class="absolute inset-0 w-full h-full object-cover -z-10" loading="lazy" />
+    <div class="absolute inset-0 bg-black/50"></div>
+    <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white" data-aos="zoom-in">Mauerwerksbau Projekte</h1>
+  </section>
+<section class="w-full py-20 bg-gray-50 fade-parallax">
+  <div class="px-4 sm:px-6 lg:px-8 mb-10">
+    <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">
+      &larr; Zurück zur Übersicht
+    </a>
+    <hr class="mt-4 border-t border-gray-300/50 w-24">
+  </div>
+
+  <div class="columns-1 sm:columns-2 lg:columns-3 gap-4 gallery px-4 sm:px-6 lg:px-8" data-aos="fade-up">
+    <a href="../images/hero-leistungen.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="50" aria-label="Mauerwerksbau Projekt 1">
+      <img src="../images/hero-leistungen.jpg" alt="Mauerwerksbau 1" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/mauerwerksbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="100" aria-label="Mauerwerksbau Projekt 2">
+      <img src="../images/mauerwerksbau.jpg" alt="Mauerwerksbau 2" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/holzbau.webp" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="150" aria-label="Mauerwerksbau Projekt 3">
+      <img src="../images/holzbau.webp" alt="Mauerwerksbau 3" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/kanalbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="200" aria-label="Mauerwerksbau Projekt 4">
+      <img src="../images/kanalbau.jpg" alt="Mauerwerksbau 4" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/mauerwerksbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="250" aria-label="Mauerwerksbau Projekt 5">
+      <img src="../images/mauerwerksbau.jpg" alt="Mauerwerksbau 5" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/pexels-kawserhamid-176342.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="300" aria-label="Mauerwerksbau Projekt 6">
+      <img src="../images/pexels-kawserhamid-176342.jpg" alt="Mauerwerksbau 6" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/pexels-yury-kim-181374-585418.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="350" aria-label="Mauerwerksbau Projekt 7">
+      <img src="../images/pexels-yury-kim-181374-585418.jpg" alt="Mauerwerksbau 7" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="400" aria-label="Mauerwerksbau Projekt 8">
+      <img src="../images/stahlbau.jpg" alt="Mauerwerksbau 8" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbetonbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="450" aria-label="Mauerwerksbau Projekt 9">
+      <img src="../images/stahlbetonbau.jpg" alt="Mauerwerksbau 9" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/unsere_strategie_2.png" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="500" aria-label="Mauerwerksbau Projekt 10">
+      <img src="../images/unsere_strategie_2.png" alt="Mauerwerksbau 10" loading="lazy" class="w-full h-auto" />
+    </a>
+  </div>
+</section>
+
+
+
+  </main>
+  <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
+    <div class="space-y-4">
+      <nav class="space-x-4">
+        <a href="../index.html">Startseite</a>
+        <a href="../leistungen.html">Leistungen</a>
+        <a href="../referenzen.html">Referenzen</a>
+        <a href="../wissen.html">Wissen</a>
+        <a href="../karriere.html">Karriere</a>
+        <a href="../kontakt.html">Kontakt</a>
+      </nav>
+      <div class="flex justify-center space-x-6 text-xl mt-4">
+        <a href="https://www.facebook.com/people/HK-Bauunternehmung-GmbH/100087217129678/" target="_blank" aria-label="Facebook">
+          <i aria-hidden="true" class="fab fa-facebook-f"></i>
+        </a>
+        <a href="https://www.instagram.com/hk.bau/" target="_blank" aria-label="Instagram">
+          <i aria-hidden="true" class="fab fa-instagram"></i>
+        </a>
+        <a href="https://www.linkedin.com" target="_blank" aria-label="LinkedIn">
+          <i aria-hidden="true" class="fab fa-linkedin-in"></i>
+        </a>
+      </div>
+      <p>© <span class="current-year"></span> HK Bau GmbH. Alle Rechte vorbehalten.</p>
+      <p class="text-xs">
+        <a href="../impressum.html">Impressum</a> | <a href="../datenschutzerklaerung.html">Datenschutz</a>
+      </p>
+    </div>
+  </footer>
+  <button id="scrollToTopBtn" class="hidden fixed bottom-6 right-6 bg-primary-color text-secondary-color p-3 rounded-full shadow-lg hover:bg-primary-hover transition" aria-label="Nach oben scrollen">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
+    </svg>
+  </button>
+  <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
+</body>
+</html>

--- a/Referenzen/stahlbau.html
+++ b/Referenzen/stahlbau.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Recommended favicon links -->
+  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <meta name="apple-mobile-web-app-title" content="HK Bau" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <title>Stahlbau Projekte</title>
+  <meta name="description" content="Referenzen und Projektbeispiele im Bereich Stahlbau von HK Bau GmbH in Stuttgart und Umgebung" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css" />
+  <link rel="stylesheet" href="../css/style.css" />
+
+
+<!-- Open Graph / Facebook -->
+<meta property="og:title" content="Stahlbau Projekte | HK Bau GmbH" />
+<meta property="og:description" content="Einblicke in unsere abgeschlossenen Stahlbau-Projekte." />
+<meta property="og:image" content="https://hkbau.de/images/stahlbau.jpg" />
+<meta property="og:url" content="https://hkbau.de/referenzen/stahlbau.html" />
+
+<!-- Twitter Card -->
+<meta name="twitter:title" content="Stahlbau Projekte | HK Bau GmbH" />
+<meta name="twitter:description" content="Stahlbauarbeiten aus unserer Referenzgalerie – HK Bau GmbH." />
+<meta name="twitter:image" content="https://hkbau.de/images/stahlbau.jpg" />
+<meta name="twitter:card" content="summary_large_image" />
+
+
+</head>
+<body class="font-[Inter] overflow-x-hidden">
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+  <script src="../js/app.js" defer></script>
+  <div class="page-transition-overlay flex items-center justify-center">
+    <div class="flex flex-col items-center space-y-4 animate-fade-in">
+      <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
+      </div>
+      <span class="text-white text-sm tracking-wide">Lädt...</span>
+    </div>
+  </div>
+
+
+<header class="bg-transparent fixed top-0 left-0 w-full z-50 transition duration-300" id="navbar">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+    <div class="logo-container">
+      <a href="../index.html" class="flex items-center relative z-20">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow" loading="lazy" />
+        <span class="text-white font-bold ml-2">HK Bau</span>
+      </a>
+    </div>
+    <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium text-white">
+      <a href="../index.html" class="hover:underline">Startseite</a>
+      <a href="../leistungen.html" class="hover:underline">Leistungen</a>
+      <a href="../referenzen.html" class="hover:underline">Referenzen</a>
+      <a href="../wissen.html" class="hover:underline">Wissen</a>
+      <a href="../karriere.html" class="hover:underline">Karriere</a>
+      <a href="../kontakt.html" class="hover:underline">Kontakt</a>
+    </nav>
+    <button id="mobile-menu-button" class="md:hidden focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)]" aria-expanded="false" aria-controls="mobile-menu">
+      <svg class="h-6 w-6 fill-current text-white" viewBox="0 0 24 24">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Mobile menu -->
+  <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out z-40">
+    <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
+      <a href="../index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
+      <a href="../leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
+      <a href="../referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
+      <a href="../wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <a href="../karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
+      <a href="../kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
+    </div>
+  </nav>
+</header>
+
+
+
+
+  <main>
+  <section class="relative h-[100vh] md:h-[600px] flex items-center justify-center overflow-hidden">
+    <img src="../images/stahlbau.jpg" alt="Stahlbau" class="absolute inset-0 w-full h-full object-cover -z-10" loading="lazy" />
+    <div class="absolute inset-0 bg-black/50"></div>
+    <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white" data-aos="zoom-in">Stahlbau Projekte</h1>
+  </section>
+<section class="w-full py-20 bg-gray-50 fade-parallax">
+  <div class="px-4 sm:px-6 lg:px-8 mb-10">
+    <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">
+      &larr; Zurück zur Übersicht
+    </a>
+    <hr class="mt-4 border-t border-gray-300/50 w-24">
+  </div>
+
+  <div class="columns-1 sm:columns-2 lg:columns-3 gap-4 gallery px-4 sm:px-6 lg:px-8" data-aos="fade-up">
+    <a href="../images/hero-leistungen.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="50" aria-label="Stahlbau Projekt 1">
+      <img src="../images/hero-leistungen.jpg" alt="Stahlbau 1" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="100" aria-label="Stahlbau Projekt 2">
+      <img src="../images/stahlbau.jpg" alt="Stahlbau 2" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/holzbau.webp" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="150" aria-label="Stahlbau Projekt 3">
+      <img src="../images/holzbau.webp" alt="Stahlbau 3" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/kanalbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="200" aria-label="Stahlbau Projekt 4">
+      <img src="../images/kanalbau.jpg" alt="Stahlbau 4" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/mauerwerksbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="250" aria-label="Stahlbau Projekt 5">
+      <img src="../images/mauerwerksbau.jpg" alt="Stahlbau 5" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/pexels-kawserhamid-176342.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="300" aria-label="Stahlbau Projekt 6">
+      <img src="../images/pexels-kawserhamid-176342.jpg" alt="Stahlbau 6" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/pexels-yury-kim-181374-585418.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="350" aria-label="Stahlbau Projekt 7">
+      <img src="../images/pexels-yury-kim-181374-585418.jpg" alt="Stahlbau 7" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="400" aria-label="Stahlbau Projekt 8">
+      <img src="../images/stahlbau.jpg" alt="Stahlbau 8" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbetonbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="450" aria-label="Stahlbau Projekt 9">
+      <img src="../images/stahlbetonbau.jpg" alt="Stahlbau 9" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/unsere_strategie_2.png" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="500" aria-label="Stahlbau Projekt 10">
+      <img src="../images/unsere_strategie_2.png" alt="Stahlbau 10" loading="lazy" class="w-full h-auto" />
+    </a>
+  </div>
+</section>
+
+
+
+  </main>
+  <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
+    <div class="space-y-4">
+      <nav class="space-x-4">
+        <a href="../index.html">Startseite</a>
+        <a href="../leistungen.html">Leistungen</a>
+        <a href="../referenzen.html">Referenzen</a>
+        <a href="../wissen.html">Wissen</a>
+        <a href="../karriere.html">Karriere</a>
+        <a href="../kontakt.html">Kontakt</a>
+      </nav>
+      <div class="flex justify-center space-x-6 text-xl mt-4">
+        <a href="https://www.facebook.com/people/HK-Bauunternehmung-GmbH/100087217129678/" target="_blank" aria-label="Facebook">
+          <i aria-hidden="true" class="fab fa-facebook-f"></i>
+        </a>
+        <a href="https://www.instagram.com/hk.bau/" target="_blank" aria-label="Instagram">
+          <i aria-hidden="true" class="fab fa-instagram"></i>
+        </a>
+        <a href="https://www.linkedin.com" target="_blank" aria-label="LinkedIn">
+          <i aria-hidden="true" class="fab fa-linkedin-in"></i>
+        </a>
+      </div>
+      <p>© <span class="current-year"></span> HK Bau GmbH. Alle Rechte vorbehalten.</p>
+      <p class="text-xs">
+        <a href="../impressum.html">Impressum</a> | <a href="../datenschutzerklaerung.html">Datenschutz</a>
+      </p>
+    </div>
+  </footer>
+  <button id="scrollToTopBtn" class="hidden fixed bottom-6 right-6 bg-primary-color text-secondary-color p-3 rounded-full shadow-lg hover:bg-primary-hover transition" aria-label="Nach oben scrollen">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
+    </svg>
+  </button>
+  <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
+</body>
+</html>

--- a/Website/index.html
+++ b/Website/index.html
@@ -330,7 +330,7 @@
     </a>
 
     <!-- Mauerwerksbau -->
-    <a href="../Referenzen/rohbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50">
+    <a href="../Referenzen/mauerwerksbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50">
       <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
         <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
           <path d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" />
@@ -352,7 +352,7 @@
     </a>
 
     <!-- Stahlbau -->
-    <a href="../Referenzen/abdichtungstechnik.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50">
+    <a href="../Referenzen/stahlbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50">
       <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
         <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
           <path d="M6 3v18M18 3v18M3 6h18M3 18h18" />

--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -181,7 +181,7 @@
       <p class="text-sm text-gray-600 group-hover:text-white">Robuste Konstruktionen.</p>
     </a>
 
-    <a href="../Referenzen/rohbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Mauerwerksbau erfahren">
+    <a href="../Referenzen/mauerwerksbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Mauerwerksbau erfahren">
       <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
         <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
           <path d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" />
@@ -201,7 +201,7 @@
       <p class="text-sm text-gray-600 group-hover:text-white">Ökologisch und modern.</p>
     </a>
 
-    <a href="../Referenzen/abdichtungstechnik.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Stahlbau erfahren">
+    <a href="../Referenzen/stahlbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Stahlbau erfahren">
       <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
         <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
           <path d="M6 3v18M18 3v18M3 6h18M3 18h18" />
@@ -223,7 +223,8 @@
   </div>
 
   <!-- Erdbau -->
-  <div id="erdbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg group" data-aos="fade-up">
+  <a href="../Referenzen/erdbau.html" class="block group" aria-label="Erdbau Referenzen">
+  <div id="erdbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up">
     <img src="../images/erdbau.jpg" alt="Erdbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Erdbau+Bild';" />
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
@@ -236,9 +237,11 @@
       </ul>
     </div>
   </div>
+  </a>
 
   <!-- Kanalbau -->
-  <div id="kanalbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg group" data-aos="fade-up" data-aos-delay="100">
+  <a href="../Referenzen/kanalbau.html" class="block group" aria-label="Kanalbau Referenzen">
+  <div id="kanalbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg" data-aos="fade-up" data-aos-delay="100">
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
         
@@ -251,10 +254,12 @@
     </div>
     <img src="../images/kanalbau.jpg" alt="Kanalbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Kanalbau+Bild';" />
   </div>
+  </a>
 
 
  <!-- Stahlbetonbau -->
-  <div id="stahlbetonbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg group" data-aos="fade-up" data-aos-delay="150">
+  <a href="../Referenzen/stahlbetonbau.html" class="block group" aria-label="Stahlbetonbau Referenzen">
+  <div id="stahlbetonbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up" data-aos-delay="150">
     <img src="../images/stahlbetonbau.jpg" alt="Stahlbetonbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Stahlbetonbau+Bild';" />
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
@@ -267,9 +272,11 @@
       </ul>
     </div>
   </div>
+  </a>
 
   <!-- Mauerwerksbau -->
-  <div id="mauerwerksbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg group" data-aos="fade-up" data-aos-delay="200">
+  <a href="../Referenzen/mauerwerksbau.html" class="block group" aria-label="Mauerwerksbau Referenzen">
+  <div id="mauerwerksbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg" data-aos="fade-up" data-aos-delay="200">
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
         
@@ -282,9 +289,11 @@
     </div>
     <img src="../images/mauerwerksbau.jpg" alt="Mauerwerksbau" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" loading="lazy" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Mauerwerksbau+Bild';" />
   </div>
+  </a>
 
   <!-- Holzbau -->
-  <div id="holzbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg group" data-aos="fade-up" data-aos-delay="250">
+  <a href="../Referenzen/holzbau.html" class="block group" aria-label="Holzbau Referenzen">
+  <div id="holzbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up" data-aos-delay="250">
     <img src="../images/holzbau.webp" alt="Holzbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Holzbau+Bild';" />
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
@@ -297,9 +306,11 @@
       </ul>
     </div>
   </div>
+  </a>
 
   <!-- Stahlbau -->
-  <div id="stahlbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg group" data-aos="fade-up" data-aos-delay="300">
+  <a href="../Referenzen/stahlbau.html" class="block group" aria-label="Stahlbau Referenzen">
+  <div id="stahlbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg" data-aos="fade-up" data-aos-delay="300">
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
         
@@ -312,6 +323,7 @@
     </div>
     <img src="../images/stahlbau.jpg" alt="Stahlbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Stahlbau+Bild';" />
   </div>
+  </a>
   
 </section>
 

--- a/Website/referenzen.html
+++ b/Website/referenzen.html
@@ -162,7 +162,7 @@
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10" data-aos="fade-up">
 
     <!-- Erdbau -->
-    <a href="Referenzen/erdbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="../Referenzen/erdbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="../images/erdbau.jpg" alt="Erdbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -182,7 +182,7 @@
     </a>
 
     <!-- Kanalbau -->
-    <a href="Referenzen/kanalbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="../Referenzen/kanalbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="../images/kanalbau.jpg" alt="Kanalbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -202,7 +202,7 @@
     </a>
 
     <!-- Stahlbetonbau -->
-    <a href="Referenzen/stahlbetonbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="../Referenzen/stahlbetonbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="../images/stahlbetonbau.jpg" alt="Stahlbetonbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -222,7 +222,7 @@
     </a>
 
     <!-- Mauerwerksbau -->
-    <a href="Referenzen/mauerwerksbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="../Referenzen/mauerwerksbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="../images/mauerwerksbau.jpg" alt="Mauerwerksbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -242,7 +242,7 @@
     </a>
 
     <!-- Holzbau -->
-    <a href="Referenzen/holzbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="../Referenzen/holzbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="../images/holzbau.webp" alt="Holzbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -262,7 +262,7 @@
     </a>
 
     <!-- Stahlbau -->
-    <a href="Referenzen/stahlbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="../Referenzen/stahlbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="../images/stahlbau.jpg" alt="Stahlbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- make each service section on Leistungen page wrap in a link to its gallery

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6878ae01cc6c832c8ebfcff5b72f02ad