### PR TITLE
Add Abbruch & Rückbau reference page

### DIFF
--- a/Referenzen/abbruch-und-ruckbau.html
+++ b/Referenzen/abbruch-und-ruckbau.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Recommended favicon links -->
+  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <meta name="apple-mobile-web-app-title" content="HK Bau" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <title>Abbruch &amp; Rückbau</title>
+  <meta name="description" content="Referenzen und Projektbeispiele im Bereich Erdbau von HK Bau GmbH in Stuttgart und Umgebung" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css" />
+  <link rel="stylesheet" href="../css/style.css" />
+
+
+<!-- Open Graph / Facebook -->
+<meta property="og:title" content="Abbruch &amp; Rückbau | HK Bau GmbH" />
+<meta property="og:description" content="Einblicke in unsere abgeschlossenen Erdbau-Projekte." />
+<meta property="og:image" content="https://hkbau.de/images/erdbau.jpg" />
+<meta property="og:url" content="https://hkbau.de/referenzen/erdbau.html" />
+
+<!-- Twitter Card -->
+<meta name="twitter:title" content="Abbruch &amp; Rückbau | HK Bau GmbH" />
+<meta name="twitter:description" content="Erdbauarbeiten aus unserer Referenzgalerie – HK Bau GmbH." />
+<meta name="twitter:image" content="https://hkbau.de/images/erdbau.jpg" />
+<meta name="twitter:card" content="summary_large_image" />
+
+
+</head>
+<body class="font-[Inter] overflow-x-hidden">
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+  <script src="../js/app.js" defer></script>
+  <div class="page-transition-overlay flex items-center justify-center">
+    <div class="flex flex-col items-center space-y-4 animate-fade-in">
+      <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" loading="lazy" />
+      </div>
+      <span class="text-white text-sm tracking-wide">Lädt...</span>
+    </div>
+  </div>
+
+
+<header class="bg-transparent fixed top-0 left-0 w-full z-50 transition duration-300" id="navbar">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+    <div class="logo-container">
+      <a href="../Website/index.html" class="flex items-center relative z-20">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow" loading="lazy" />
+        <span class="text-white font-bold ml-2">HK Bau</span>
+      </a>
+    </div>
+    <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium text-white">
+      <a href="../Website/index.html" class="hover:underline">Startseite</a>
+      <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
+      <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
+      <a href="../Website/wissen.html" class="hover:underline">Wissen</a>
+      <a href="../Website/karriere.html" class="hover:underline">Karriere</a>
+      <a href="../Website/kontakt.html" class="hover:underline">Kontakt</a>
+    </nav>
+    <button id="mobile-menu-button" class="md:hidden focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)]" aria-expanded="false" aria-controls="mobile-menu">
+      <svg class="h-6 w-6 fill-current text-white" viewBox="0 0 24 24">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Mobile menu -->
+  <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out z-40">
+    <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
+      <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
+      <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
+      <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
+      <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <a href="../Website/karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
+      <a href="../Website/kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
+    </div>
+  </nav>
+</header>
+
+
+
+
+  <main>
+  <section class="relative h-[100vh] md:h-[600px] flex items-center justify-center overflow-hidden">
+    <img src="../images/erdbau.jpg" alt="Abbruch &amp; Rückbau" class="absolute inset-0 w-full h-full object-cover -z-10" loading="lazy" />
+    <div class="absolute inset-0 bg-black/50"></div>
+    <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white" data-aos="zoom-in">Abbruch &amp; Rückbau</h1>
+    <p class="relative z-10 text-lg md:text-xl text-white mt-4" data-aos="zoom-in" data-aos-delay="150">Kontrollierte Rückbauarbeiten für neue Perspektiven.</p>
+  </section>
+<section class="w-full py-20 bg-gray-50 fade-parallax">
+  <div class="px-4 sm:px-6 lg:px-8 mb-10">
+    <a href="../Website/referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">
+      Startseite > Referenzen > Abbruch &amp; Rückbau
+    </a>
+    <hr class="mt-4 border-t border-gray-300/50 w-24">
+  </div>
+
+  <div class="columns-1 sm:columns-2 lg:columns-3 gap-4 gallery px-4 sm:px-6 lg:px-8" data-aos="fade-up">
+    <a href="../images/referenzen/abbruch/abbruch1.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="50" aria-label="Abbruch &amp; Rückbau Projekt 1">
+      <img src="../images/referenzen/abbruch/abbruch1.jpg" alt="Abbruch &amp; Rückbau 1" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/referenzen/abbruch/abbruch2.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="100" aria-label="Abbruch &amp; Rückbau Projekt 2">
+      <img src="../images/referenzen/abbruch/abbruch2.jpg" alt="Abbruch &amp; Rückbau 2" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/referenzen/abbruch/abbruch3.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="150" aria-label="Abbruch &amp; Rückbau Projekt 3">
+      <img src="../images/referenzen/abbruch/abbruch3.jpg" alt="Abbruch &amp; Rückbau 3" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/referenzen/abbruch/abbruch4.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="200" aria-label="Abbruch &amp; Rückbau Projekt 4">
+      <img src="../images/referenzen/abbruch/abbruch4.jpg" alt="Abbruch &amp; Rückbau 4" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/referenzen/abbruch/abbruch5.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="250" aria-label="Abbruch &amp; Rückbau Projekt 5">
+      <img src="../images/referenzen/abbruch/abbruch5.jpg" alt="Abbruch &amp; Rückbau 5" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/referenzen/abbruch/abbruch6.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="300" aria-label="Abbruch &amp; Rückbau Projekt 6">
+      <img src="../images/referenzen/abbruch/abbruch6.jpg" alt="Abbruch &amp; Rückbau 6" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/referenzen/abbruch/abbruch7.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="350" aria-label="Abbruch &amp; Rückbau Projekt 7">
+      <img src="../images/referenzen/abbruch/abbruch7.jpg" alt="Abbruch &amp; Rückbau 7" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/referenzen/abbruch/abbruch8.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="400" aria-label="Abbruch &amp; Rückbau Projekt 8">
+      <img src="../images/referenzen/abbruch/abbruch8.jpg" alt="Abbruch &amp; Rückbau 8" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/referenzen/abbruch/abbruch9.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="450" aria-label="Abbruch &amp; Rückbau Projekt 9">
+      <img src="../images/referenzen/abbruch/abbruch9.jpg" alt="Abbruch &amp; Rückbau 9" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/referenzen/abbruch/abbruch10.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="500" aria-label="Abbruch &amp; Rückbau Projekt 10">
+      <img src="../images/referenzen/abbruch/abbruch10.jpg" alt="Abbruch &amp; Rückbau 10" loading="lazy" class="w-full h-auto" />
+    </a>
+  </div>
+  <div class="text-center mt-12">
+    <a href="../referenzen.html" class="inline-block bg-primary-color text-secondary-color font-semibold py-3 px-8 rounded-lg transition transform hover:scale-110">Zurück zur Übersicht</a>
+  </div>
+</section>
+
+
+
+  </main>
+  <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
+    <div class="space-y-4">
+      <nav class="space-x-4">
+        <a href="../Website/index.html">Startseite</a>
+        <a href="../Website/leistungen.html">Leistungen</a>
+        <a href="../Website/referenzen.html">Referenzen</a>
+        <a href="../Website/wissen.html">Wissen</a>
+        <a href="../Website/karriere.html">Karriere</a>
+        <a href="../Website/kontakt.html">Kontakt</a>
+      </nav>
+      <div class="flex justify-center space-x-6 text-xl mt-4">
+        <a href="https://www.facebook.com/people/HK-Bauunternehmung-GmbH/100087217129678/" target="_blank" aria-label="Facebook">
+          <i aria-hidden="true" class="fab fa-facebook-f"></i>
+        </a>
+        <a href="https://www.instagram.com/hk.bau/" target="_blank" aria-label="Instagram">
+          <i aria-hidden="true" class="fab fa-instagram"></i>
+        </a>
+        <a href="https://www.linkedin.com" target="_blank" aria-label="LinkedIn">
+          <i aria-hidden="true" class="fab fa-linkedin-in"></i>
+        </a>
+      </div>
+      <p>© <span class="current-year"></span> HK Bau GmbH. Alle Rechte vorbehalten.</p>
+      <p class="text-xs">
+        <a href="../Website/impressum.html">Impressum</a> | <a href="../Website/datenschutzerklaerung.html">Datenschutz</a>
+      </p>
+    </div>
+  </footer>
+  <button id="scrollToTopBtn" class="hidden fixed bottom-6 right-6 bg-primary-color text-secondary-color p-3 rounded-full shadow-lg hover:bg-primary-hover transition" aria-label="Nach oben scrollen">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
+    </svg>
+  </button>
+  <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- duplicate erdbau reference page to create **Abbruch & Rückbau**
- adjust titles, hero text and breadcrumb text
- swap gallery images for abbruch examples
- add navigation button back to overview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878ea6dd3f8832c8a54cd63b310ed0b