### PR TITLE
Remove Wissen links from nav

### DIFF
--- a/Referenzen/abbruch-und-ruckbau.html
+++ b/Referenzen/abbruch-und-ruckbau.html
@@ -60,7 +60,7 @@
       <a href="../Website/index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
-      <a href="../Website/wissen.html" class="hover:underline">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
       <a href="../Website/karriere.html" class="hover:underline">Karriere</a>
       <a href="../Website/kontakt.html" class="hover:underline">Kontakt</a>
     </nav>
@@ -77,7 +77,7 @@
       <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-      <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
       <a href="../Website/karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
       <a href="../Website/kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
     </div>
@@ -148,7 +148,7 @@
         <a href="../Website/index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
-        <a href="../Website/wissen.html">Wissen</a>
+        <!-- <a href="../Website/wissen.html">Wissen</a> -->
         <a href="../Website/karriere.html">Karriere</a>
         <a href="../Website/kontakt.html">Kontakt</a>
       </nav>

--- a/Referenzen/erdbau.html
+++ b/Referenzen/erdbau.html
@@ -60,7 +60,7 @@
       <a href="../Website/index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
-      <a href="../Website/wissen.html" class="hover:underline">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
       <a href="../Website/karriere.html" class="hover:underline">Karriere</a>
       <a href="../Website/kontakt.html" class="hover:underline">Kontakt</a>
     </nav>
@@ -77,7 +77,7 @@
       <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-      <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
       <a href="../Website/karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
       <a href="../Website/kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
     </div>
@@ -144,7 +144,7 @@
         <a href="../Website/index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
-        <a href="../Website/wissen.html">Wissen</a>
+        <!-- <a href="../Website/wissen.html">Wissen</a> -->
         <a href="../Website/karriere.html">Karriere</a>
         <a href="../Website/kontakt.html">Kontakt</a>
       </nav>

--- a/Referenzen/holzbau.html
+++ b/Referenzen/holzbau.html
@@ -60,7 +60,7 @@
       <a href="../Website/index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
-      <a href="../Website/wissen.html" class="hover:underline">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
       <a href="../Website/karriere.html" class="hover:underline">Karriere</a>
       <a href="../Website/kontakt.html" class="hover:underline">Kontakt</a>
     </nav>
@@ -77,7 +77,7 @@
       <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-      <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
       <a href="../Website/karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
       <a href="../Website/kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
     </div>
@@ -144,7 +144,7 @@
         <a href="../Website/index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
-        <a href="../Website/wissen.html">Wissen</a>
+        <!-- <a href="../Website/wissen.html">Wissen</a> -->
         <a href="../Website/karriere.html">Karriere</a>
         <a href="../Website/kontakt.html">Kontakt</a>
       </nav>

--- a/Referenzen/kanalbau.html
+++ b/Referenzen/kanalbau.html
@@ -60,7 +60,7 @@
       <a href="../Website/index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
-      <a href="../Website/wissen.html" class="hover:underline">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
       <a href="../Website/karriere.html" class="hover:underline">Karriere</a>
       <a href="../Website/kontakt.html" class="hover:underline">Kontakt</a>
     </nav>
@@ -77,7 +77,7 @@
       <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-      <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
       <a href="../Website/karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
       <a href="../Website/kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
     </div>
@@ -144,7 +144,7 @@
         <a href="../Website/index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
-        <a href="../Website/wissen.html">Wissen</a>
+        <!-- <a href="../Website/wissen.html">Wissen</a> -->
         <a href="../Website/karriere.html">Karriere</a>
         <a href="../Website/kontakt.html">Kontakt</a>
       </nav>

--- a/Referenzen/mauerwerksbau.html
+++ b/Referenzen/mauerwerksbau.html
@@ -60,7 +60,7 @@
       <a href="../index.html" class="hover:underline">Startseite</a>
       <a href="../leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../referenzen.html" class="hover:underline">Referenzen</a>
-      <a href="../wissen.html" class="hover:underline">Wissen</a>
+      <!-- <a href="../wissen.html" class="hover:underline">Wissen</a> -->
       <a href="../karriere.html" class="hover:underline">Karriere</a>
       <a href="../kontakt.html" class="hover:underline">Kontakt</a>
     </nav>
@@ -77,7 +77,7 @@
       <a href="../index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-      <a href="../wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <!-- <a href="../wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
       <a href="../karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
       <a href="../kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
     </div>
@@ -144,7 +144,7 @@
         <a href="../index.html">Startseite</a>
         <a href="../leistungen.html">Leistungen</a>
         <a href="../referenzen.html">Referenzen</a>
-        <a href="../wissen.html">Wissen</a>
+        <!-- <a href="../wissen.html">Wissen</a> -->
         <a href="../karriere.html">Karriere</a>
         <a href="../kontakt.html">Kontakt</a>
       </nav>

--- a/Referenzen/stahlbau.html
+++ b/Referenzen/stahlbau.html
@@ -60,7 +60,7 @@
       <a href="../index.html" class="hover:underline">Startseite</a>
       <a href="../leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../referenzen.html" class="hover:underline">Referenzen</a>
-      <a href="../wissen.html" class="hover:underline">Wissen</a>
+      <!-- <a href="../wissen.html" class="hover:underline">Wissen</a> -->
       <a href="../karriere.html" class="hover:underline">Karriere</a>
       <a href="../kontakt.html" class="hover:underline">Kontakt</a>
     </nav>
@@ -77,7 +77,7 @@
       <a href="../index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-      <a href="../wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <!-- <a href="../wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
       <a href="../karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
       <a href="../kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
     </div>
@@ -144,7 +144,7 @@
         <a href="../index.html">Startseite</a>
         <a href="../leistungen.html">Leistungen</a>
         <a href="../referenzen.html">Referenzen</a>
-        <a href="../wissen.html">Wissen</a>
+        <!-- <a href="../wissen.html">Wissen</a> -->
         <a href="../karriere.html">Karriere</a>
         <a href="../kontakt.html">Kontakt</a>
       </nav>

--- a/Referenzen/stahlbetonbau.html
+++ b/Referenzen/stahlbetonbau.html
@@ -60,7 +60,7 @@
       <a href="../Website/index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
-      <a href="../Website/wissen.html" class="hover:underline">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
       <a href="../Website/karriere.html" class="hover:underline">Karriere</a>
       <a href="../Website/kontakt.html" class="hover:underline">Kontakt</a>
     </nav>
@@ -77,7 +77,7 @@
       <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-      <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+      <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
       <a href="../Website/karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
       <a href="../Website/kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
     </div>
@@ -144,7 +144,7 @@
         <a href="../Website/index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
-        <a href="../Website/wissen.html">Wissen</a>
+        <!-- <a href="../Website/wissen.html">Wissen</a> -->
         <a href="../Website/karriere.html">Karriere</a>
         <a href="../Website/kontakt.html">Kontakt</a>
       </nav>

--- a/Website/index.html
+++ b/Website/index.html
@@ -101,7 +101,7 @@
         <a href="index.html">Startseite</a>
         <a href="leistungen.html">Leistungen</a>
         <a href="referenzen.html">Referenzen</a>
-        <a href="wissen.html">Wissen</a>
+        <!-- <a href="wissen.html">Wissen</a> -->
         <a href="karriere.html">Karriere</a>
         <a href="kontakt.html">Kontakt</a>
       </nav>
@@ -118,7 +118,7 @@
         <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
         <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
         <a href="referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-        <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+        <!-- <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
         <a href="karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
         <a href="kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
       </div>
@@ -657,7 +657,7 @@
       <a href="index.html">Startseite</a>
       <a href="leistungen.html">Leistungen</a>
       <a href="referenzen.html">Referenzen</a>
-      <a href="wissen.html">Wissen</a>
+      <!-- <a href="wissen.html">Wissen</a> -->
       <a href="karriere.html">Karriere</a>
       <a href="kontakt.html">Kontakt</a>
     </nav>

--- a/Website/karriere.html
+++ b/Website/karriere.html
@@ -140,7 +140,7 @@
                 <a href="index.html">Startseite</a>
                 <a href="leistungen.html">Leistungen</a>
                 <a href="referenzen.html">Referenzen</a>
-                <a href="wissen.html">Wissen</a> 
+                <!-- <a href="wissen.html">Wissen</a> --> 
                 <a href="karriere.html">Karriere</a>
                 <a href="kontakt.html">Kontakt</a>
             </nav>
@@ -156,7 +156,7 @@
                 <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
                 <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
                 <a href="referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-                <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+                <!-- <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
                 <a href="karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
                 <a href="kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
             </div>
@@ -315,7 +315,7 @@
       <a href="index.html">Startseite</a>
       <a href="leistungen.html">Leistungen</a>
       <a href="referenzen.html">Referenzen</a>
-      <a href="wissen.html">Wissen</a>
+      <!-- <a href="wissen.html">Wissen</a> -->
       <a href="karriere.html">Karriere</a>
       <a href="kontakt.html">Kontakt</a>
     </nav>

--- a/Website/kontakt.html
+++ b/Website/kontakt.html
@@ -103,7 +103,7 @@
                 <a href="index.html">Startseite</a>
                 <a href="leistungen.html">Leistungen</a>
                 <a href="referenzen.html">Referenzen</a>
-                <a href="wissen.html">Wissen</a>
+                <!-- <a href="wissen.html">Wissen</a> -->
                  <a href="karriere.html">Karriere</a>
                 <a href="kontakt.html">Kontakt</a>
             </nav>
@@ -120,7 +120,7 @@
                 <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
                 <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
                 <a href="referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-                <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+                <!-- <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
                 <a href="karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
                 <a href="kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
             </div>
@@ -285,7 +285,7 @@
       <a href="index.html">Startseite</a>
       <a href="leistungen.html">Leistungen</a>
       <a href="referenzen.html">Referenzen</a>
-      <a href="wissen.html">Wissen</a>
+      <!-- <a href="wissen.html">Wissen</a> -->
       <a href="karriere.html">Karriere</a>
       <a href="kontakt.html">Kontakt</a>
     </nav>

--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -97,7 +97,7 @@
                 <a href="index.html" class="hover:text-primary-color transition">Startseite</a>
                 <a href="leistungen.html" class="hover:text-primary-color transition">Leistungen</a>
                 <a href="referenzen.html" class="hover:text-primary-color transition">Referenzen</a>
-                <a href="wissen.html" class="hover:text-primary-color transition">Wissen</a> <a href="karriere.html"
+                <!-- <a href="wissen.html" class="hover:text-primary-color transition">Wissen</a> --> <a href="karriere.html"
                     class="hover:text-primary-color transition">Karriere</a>
                 <a href="kontakt.html" class="hover:text-primary-color transition">Kontakt</a>
             </nav>
@@ -118,8 +118,8 @@
                     class="block py-2 px-3 text-base font-medium hover:bg-gray-700 rounded">Leistungen</a>
                 <a href="referenzen.html"
                     class="block py-2 px-3 text-base font-medium hover:bg-gray-700 rounded">Referenzen</a>
-                <a href="wissen.html"
-                    class="block py-2 px-3 text-base font-medium hover:bg-gray-700 rounded">Wissen</a> <a
+                <!-- <a href="wissen.html"
+                    class="block py-2 px-3 text-base font-medium hover:bg-gray-700 rounded">Wissen</a> --> <a
                     href="karriere.html"
                     class="block py-2 px-3 text-base font-medium hover:bg-gray-700 rounded">Karriere</a>
                 <a href="kontakt.html"
@@ -453,7 +453,7 @@
       <a href="index.html">Startseite</a>
       <a href="leistungen.html">Leistungen</a>
       <a href="referenzen.html">Referenzen</a>
-      <a href="wissen.html">Wissen</a>
+      <!-- <a href="wissen.html">Wissen</a> -->
       <a href="karriere.html">Karriere</a>
       <a href="kontakt.html">Kontakt</a>
     </nav>

--- a/Website/referenzen.html
+++ b/Website/referenzen.html
@@ -105,7 +105,7 @@
                 <a href="index.html">Startseite</a>
                 <a href="leistungen.html">Leistungen</a>
                 <a href="referenzen.html">Referenzen</a>
-                <a href="wissen.html">Wissen</a>
+                <!-- <a href="wissen.html">Wissen</a> -->
                  <a href="karriere.html">Karriere</a>
                 <a href="kontakt.html">Kontakt</a>
             </nav>
@@ -122,7 +122,7 @@
                 <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
                 <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
                 <a href="referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-                <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+                <!-- <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
                 <a href="karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
                 <a href="kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
             </div>
@@ -334,7 +334,7 @@
       <a href="index.html">Startseite</a>
       <a href="leistungen.html">Leistungen</a>
       <a href="referenzen.html">Referenzen</a>
-      <a href="wissen.html">Wissen</a>
+      <!-- <a href="wissen.html">Wissen</a> -->
       <a href="karriere.html">Karriere</a>
       <a href="kontakt.html">Kontakt</a>
     </nav>

--- a/Website/sitemap.xml
+++ b/Website/sitemap.xml
@@ -25,14 +25,14 @@
     <lastmod>2025-06-06T09:37:21Z</lastmod>
     <priority>0.8</priority>
   </url>
-  <url>
-    <loc>https://www.hk-bau.net/wissen.html</loc>
-    <lastmod>2025-06-06T09:37:21Z</lastmod>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://www.hk-bau.net/wissen/betonieren-im-winter.html</loc>
-    <lastmod>2025-06-06T09:37:21Z</lastmod>
-    <priority>0.8</priority>
-  </url>
+<!--   <url> -->
+<!--     <loc>https://www.hk-bau.net/wissen.html</loc> -->
+<!--     <lastmod>2025-06-06T09:37:21Z</lastmod> -->
+<!--     <priority>0.8</priority> -->
+<!--   </url> -->
+<!--   <url> -->
+<!--     <loc>https://www.hk-bau.net/wissen/betonieren-im-winter.html</loc> -->
+<!--     <lastmod>2025-06-06T09:37:21Z</lastmod> -->
+<!--     <priority>0.8</priority> -->
+<!--   </url> -->
 </urlset>

--- a/Website/wissen.html
+++ b/Website/wissen.html
@@ -138,7 +138,7 @@
         <a href="index.html">Startseite</a>
         <a href="leistungen.html">Leistungen</a>
         <a href="referenzen.html">Referenzen</a>
-        <a href="wissen.html">Wissen</a>
+        <!-- <a href="wissen.html">Wissen</a> -->
         <a href="karriere.html">Karriere</a>
         <a href="kontakt.html">Kontakt</a>
       </nav>
@@ -153,7 +153,7 @@
         <a href="index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
         <a href="leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
         <a href="referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
-        <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a>
+        <!-- <a href="wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
         <a href="karriere.html" class="block py-2 px-3 text-base font-medium">Karriere</a>
         <a href="kontakt.html" class="block py-2 px-3 text-base font-medium">Kontakt</a>
       </div>
@@ -233,7 +233,7 @@
       <a href="index.html">Startseite</a>
       <a href="leistungen.html">Leistungen</a>
       <a href="referenzen.html">Referenzen</a>
-      <a href="wissen.html">Wissen</a>
+      <!-- <a href="wissen.html">Wissen</a> -->
       <a href="karriere.html">Karriere</a>
       <a href="kontakt.html">Kontakt</a>
     </nav>

--- a/components/modern-navigation.html
+++ b/components/modern-navigation.html
@@ -52,9 +52,9 @@
         <a href="referenzen.html" class="nav-link">
           <span>Referenzen</span>
         </a>
-        <a href="wissen.html" class="nav-link">
+        <!-- <a href="wissen.html" class="nav-link">
           <span>Wissen</span>
-        </a>
+        </a> -->
         <a href="karriere.html" class="nav-link">
           <span>Karriere</span>
         </a>
@@ -131,12 +131,12 @@
           </svg>
           <span>Referenzen</span>
         </a>
-        <a href="wissen.html" class="mobile-nav-link">
+        <!-- <a href="wissen.html" class="mobile-nav-link">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
           </svg>
           <span>Wissen</span>
-        </a>
+        </a> -->
         <a href="karriere.html" class="mobile-nav-link">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2-2v2m8 0V6a2 2 0 012 2v6a2 2 0 01-2 2H8a2 2 0 01-2-2V8a2 2 0 012-2V6"></path>


### PR DESCRIPTION
## Summary
- comment out links to `wissen.html` across the site
- hide "Wissen" entry in reusable navigation component
- comment out Wissen URLs in `sitemap.xml`

## Testing
- `grep -R "<a href=\"wissen.html\"" -n Website Referenzen components | grep -v impressum | grep -v datenschutzerklaerung`
- `grep -R "../wissen.html" -n Referenzen`


------
https://chatgpt.com/codex/tasks/task_e_6879249638fc832cab18c6dff1ae7f65