### PR TITLE
Fix Referenzen asset links

### DIFF
--- a/Website/Referenzen/abbruch-und-ruckbau.html
+++ b/Website/Referenzen/abbruch-und-ruckbau.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Recommended favicon links -->
-  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="../favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="shortcut icon" href="../favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="HK Bau" />
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="manifest" href="../site.webmanifest" />
   <title>Abbruch &amp; Rückbau</title>
   <meta name="description" content="Referenzen und Projektbeispiele im Bereich Erdbau von HK Bau GmbH in Stuttgart und Umgebung" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -51,13 +51,13 @@
 <header class="bg-transparent fixed top-0 left-0 w-full z-50 transition duration-300" id="navbar">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <div class="logo-container">
-      <a href="../Website/index.html" class="flex items-center relative z-20">
+      <a href="../index.html" class="flex items-center relative z-20">
         <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow" loading="lazy" />
         <span class="text-white font-bold ml-2">HK Bau</span>
       </a>
     </div>
     <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium text-white">
-      <a href="../Website/index.html" class="hover:underline">Startseite</a>
+      <a href="../index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
@@ -74,7 +74,7 @@
   <!-- Mobile menu -->
   <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out z-40">
     <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-      <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
+      <a href="../index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
@@ -145,7 +145,7 @@
   <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
     <div class="space-y-4">
       <nav class="space-x-4">
-        <a href="../Website/index.html">Startseite</a>
+        <a href="../index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
         <!-- <a href="../Website/wissen.html">Wissen</a> -->

--- a/Website/Referenzen/erdbau.html
+++ b/Website/Referenzen/erdbau.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Recommended favicon links -->
-  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="../favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="shortcut icon" href="../favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="HK Bau" />
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="manifest" href="../site.webmanifest" />
   <title>Erdbau Projekte</title>
   <meta name="description" content="Referenzen und Projektbeispiele im Bereich Erdbau von HK Bau GmbH in Stuttgart und Umgebung" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -51,13 +51,13 @@
 <header class="bg-transparent fixed top-0 left-0 w-full z-50 transition duration-300" id="navbar">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <div class="logo-container">
-      <a href="../Website/index.html" class="flex items-center relative z-20">
+      <a href="../index.html" class="flex items-center relative z-20">
         <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow" loading="lazy" />
         <span class="text-white font-bold ml-2">HK Bau</span>
       </a>
     </div>
     <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium text-white">
-      <a href="../Website/index.html" class="hover:underline">Startseite</a>
+      <a href="../index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
@@ -74,7 +74,7 @@
   <!-- Mobile menu -->
   <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out z-40">
     <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-      <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
+      <a href="../index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
@@ -141,7 +141,7 @@
   <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
     <div class="space-y-4">
       <nav class="space-x-4">
-        <a href="../Website/index.html">Startseite</a>
+        <a href="../index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
         <!-- <a href="../Website/wissen.html">Wissen</a> -->

--- a/Website/Referenzen/holzbau.html
+++ b/Website/Referenzen/holzbau.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Recommended favicon links -->
-  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="../favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="shortcut icon" href="../favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="HK Bau" />
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="manifest" href="../site.webmanifest" />
   <title>Holzbau Projekte</title>
   <meta name="description" content="Referenzen und Projektbeispiele im Bereich Holzbau von HK Bau GmbH in Stuttgart und Umgebung" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -51,13 +51,13 @@
 <header class="bg-transparent fixed top-0 left-0 w-full z-50 transition duration-300" id="navbar">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <div class="logo-container">
-      <a href="../Website/index.html" class="flex items-center relative z-20">
+      <a href="../index.html" class="flex items-center relative z-20">
         <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow" loading="lazy" />
         <span class="text-white font-bold ml-2">HK Bau</span>
       </a>
     </div>
     <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium text-white">
-      <a href="../Website/index.html" class="hover:underline">Startseite</a>
+      <a href="../index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
@@ -74,7 +74,7 @@
   <!-- Mobile menu -->
   <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out z-40">
     <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-      <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
+      <a href="../index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
@@ -141,7 +141,7 @@
   <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
     <div class="space-y-4">
       <nav class="space-x-4">
-        <a href="../Website/index.html">Startseite</a>
+        <a href="../index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
         <!-- <a href="../Website/wissen.html">Wissen</a> -->

--- a/Website/Referenzen/kanalbau.html
+++ b/Website/Referenzen/kanalbau.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Recommended favicon links -->
-  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="../favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="shortcut icon" href="../favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="HK Bau" />
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="manifest" href="../site.webmanifest" />
   <title>Kanalbau Projekte</title>
   <meta name="description" content="Referenzen und Projektbeispiele im Bereich Kanalbau von HK Bau GmbH in Stuttgart und Umgebung" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -51,13 +51,13 @@
 <header class="bg-transparent fixed top-0 left-0 w-full z-50 transition duration-300" id="navbar">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <div class="logo-container">
-      <a href="../Website/index.html" class="flex items-center relative z-20">
+      <a href="../index.html" class="flex items-center relative z-20">
         <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow" loading="lazy" />
         <span class="text-white font-bold ml-2">HK Bau</span>
       </a>
     </div>
     <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium text-white">
-      <a href="../Website/index.html" class="hover:underline">Startseite</a>
+      <a href="../index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
@@ -74,7 +74,7 @@
   <!-- Mobile menu -->
   <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out z-40">
     <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-      <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
+      <a href="../index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
@@ -141,7 +141,7 @@
   <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
     <div class="space-y-4">
       <nav class="space-x-4">
-        <a href="../Website/index.html">Startseite</a>
+        <a href="../index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
         <!-- <a href="../Website/wissen.html">Wissen</a> -->

--- a/Website/Referenzen/mauerwerksbau.html
+++ b/Website/Referenzen/mauerwerksbau.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Recommended favicon links -->
-  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="../favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="shortcut icon" href="../favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="HK Bau" />
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="manifest" href="../site.webmanifest" />
   <title>Mauerwerksbau Projekte</title>
   <meta name="description" content="Referenzen und Projektbeispiele im Bereich Mauerwerksbau von HK Bau GmbH in Stuttgart und Umgebung" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/Website/Referenzen/stahlbau.html
+++ b/Website/Referenzen/stahlbau.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Recommended favicon links -->
-  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="../favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="shortcut icon" href="../favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="HK Bau" />
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="manifest" href="../site.webmanifest" />
   <title>Stahlbau Projekte</title>
   <meta name="description" content="Referenzen und Projektbeispiele im Bereich Stahlbau von HK Bau GmbH in Stuttgart und Umgebung" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/Website/Referenzen/stahlbetonbau.html
+++ b/Website/Referenzen/stahlbetonbau.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Recommended favicon links -->
-  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="../favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="shortcut icon" href="../favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="HK Bau" />
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="manifest" href="../site.webmanifest" />
   <title>Stahlbetonbau Projekte</title>
   <meta name="description" content="Referenzen und Projektbeispiele im Bereich Stahlbetonbau von HK Bau GmbH in Stuttgart und Umgebung" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -51,13 +51,13 @@
 <header class="bg-transparent fixed top-0 left-0 w-full z-50 transition duration-300" id="navbar">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <div class="logo-container">
-      <a href="../Website/index.html" class="flex items-center relative z-20">
+      <a href="../index.html" class="flex items-center relative z-20">
         <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow" loading="lazy" />
         <span class="text-white font-bold ml-2">HK Bau</span>
       </a>
     </div>
     <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium text-white">
-      <a href="../Website/index.html" class="hover:underline">Startseite</a>
+      <a href="../index.html" class="hover:underline">Startseite</a>
       <a href="../Website/leistungen.html" class="hover:underline">Leistungen</a>
       <a href="../Website/referenzen.html" class="hover:underline">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="hover:underline">Wissen</a> -->
@@ -74,7 +74,7 @@
   <!-- Mobile menu -->
   <nav id="mobile-menu" aria-label="Mobile Navigation" class="md:hidden fixed inset-y-0 right-0 w-64 bg-secondary-color text-white transform translate-x-full transition-transform duration-300 ease-in-out z-40">
     <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-      <a href="../Website/index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
+      <a href="../index.html" class="block py-2 px-3 text-base font-medium">Startseite</a>
       <a href="../Website/leistungen.html" class="block py-2 px-3 text-base font-medium">Leistungen</a>
       <a href="../Website/referenzen.html" class="block py-2 px-3 text-base font-medium">Referenzen</a>
       <!-- <a href="../Website/wissen.html" class="block py-2 px-3 text-base font-medium">Wissen</a> -->
@@ -141,7 +141,7 @@
   <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
     <div class="space-y-4">
       <nav class="space-x-4">
-        <a href="../Website/index.html">Startseite</a>
+        <a href="../index.html">Startseite</a>
         <a href="../Website/leistungen.html">Leistungen</a>
         <a href="../Website/referenzen.html">Referenzen</a>
         <!-- <a href="../Website/wissen.html">Wissen</a> -->


### PR DESCRIPTION
## Summary
- fix root-relative favicon URLs for Referenzen pages
- point Referenzen 'Startseite' links to the site root

## Testing
- `grep -n '../index.html' Website/Referenzen/erdbau.html`


------
https://chatgpt.com/codex/tasks/task_e_6879f225a830832c94628e93da76e98c