### PR TITLE
Replace outdated Referenzen links with service anchors

### DIFF
--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -166,7 +166,7 @@
 <section class="space-y-24 max-w-6xl mx-auto px-6 py-24 bg-gradient-to-br from-gray-50 via-white to-gray-100 shadow-[0_0_40px_rgba(0,0,0,0.05)] rounded-[2rem] relative">
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8" data-aos="fade-up" data-aos-duration="1000">
     <!-- Erdbau -->
-    <a href="Referenzen/erdbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Erdbau erfahren">
+    <a href="leistungen.html#erdbau-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Erdbau erfahren">
      <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
     <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path d="M2 4L22 4" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
@@ -191,7 +191,7 @@
     </a>
 
     <!-- Kanalbau -->
-    <a href="Referenzen/kanalbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Kanalbau erfahren">
+    <a href="leistungen.html#kanalbau-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Kanalbau erfahren">
      <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
     <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
       <path d="M232,104H208V56h24a8,8,0,0,0,0-16H205.83A16,16,0,0,0,192,32H176a16,16,0,0,0-13.83,8H144A104.11,104.11,0,0,0,40,144v18.16A16,16,0,0,0,32,176v16a16,16,0,0,0,8,13.84V232a8,8,0,0,0,16,0V208h48v24a8,8,0,0,0,16,0V205.84A16,16,0,0,0,128,192V176a16,16,0,0,0-8-13.84V144a24,24,0,0,1,24-24h18.17A16,16,0,0,0,176,128h16a16,16,0,0,0,13.83-8H232a8,8,0,0,0,0-16ZM112,176v16H48V176Zm-8-32v16H56V144a88.1,88.1,0,0,1,88-88h16v48H144A40,40,0,0,0,104,144Zm72-32V48h16v63.8c0,.07,0,.13,0,.2Z"></path>
@@ -202,7 +202,7 @@
     </a>
 
     <!-- Stahlbetonbau -->
-    <a href="Referenzen/stahlbetonbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Stahlbetonbau erfahren">
+    <a href="leistungen.html#stahlbetonbau-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Stahlbetonbau erfahren">
       <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
         <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
           <path d="M4 4h16v16H4z" />
@@ -213,7 +213,7 @@
     </a>
 
     <!-- Mauerwerksbau -->
-    <a href="Referenzen/mauerwerksbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Mauerwerksbau erfahren">
+    <a href="leistungen.html#mauerwerksbau-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Mauerwerksbau erfahren">
 <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
     <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <rect width="18" height="18" x="3" y="3" rx="2"/>
@@ -231,7 +231,7 @@
     </a>
 
     <!-- Holzbau -->
-    <a href="Referenzen/holzbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Holzbau erfahren">
+    <a href="leistungen.html#holzbau-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Holzbau erfahren">
       <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
         <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
           <path d="M3 21h18M3 10l9-7 9 7M4 10v11h5v-7h6v7h5V10" />
@@ -242,7 +242,7 @@
     </a>
 
     <!-- Stahlbau -->
-    <a href="Referenzen/stahlbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Stahlbau erfahren">
+    <a href="leistungen.html#stahlbau-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Stahlbau erfahren">
       <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
         <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
           <path d="M6 3v18M18 3v18M3 6h18M3 18h18" />
@@ -253,7 +253,7 @@
     </a>
 
     <!-- Abbruch & Rückbau -->
-    <a href="Referenzen/abbruch-und-ruckbau.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Abbruch & Rückbau erfahren">
+    <a href="leistungen.html#abbruch-und-ruckbau-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Abbruch & Rückbau erfahren">
   <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
     <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out"
          viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -276,7 +276,7 @@
 
     
 <!-- Freianlagen -->
-<a href="Referenzen/freianlagen.html" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50">
+<a href="leistungen.html#freianlagen-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50">
   <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <!-- Structured Tree -->
@@ -298,7 +298,7 @@
 
 
 <!-- Schlüsselfertigbau -->
-<a href="Referenzen/schluesselfertigbau.html" 
+<a href="leistungen.html#schluesselfertigbau-details" 
    class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50">
 
   <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
@@ -326,7 +326,7 @@
   </div>
 
   <!-- Erdbau -->
-  <a href="Referenzen/erdbau.html" class="block group" aria-label="Erdbau Referenzen">
+  <a href="leistungen.html#erdbau-details" class="block group" aria-label="Erdbau Referenzen">
   <div id="erdbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up">
     <img src="images/erdbau.jpg" alt="Erdbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Erdbau+Bild';" />
     <div>
@@ -353,7 +353,7 @@
 </a>
 
 <!-- Kanalbau -->
-<a href="Referenzen/kanalbau.html" class="block group" aria-label="Kanalbau Referenzen">
+<a href="leistungen.html#kanalbau-details" class="block group" aria-label="Kanalbau Referenzen">
   <div id="kanalbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg" data-aos="fade-up" data-aos-delay="100">
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
@@ -380,7 +380,7 @@
  
 
  <!-- STAHLBETONBAU -->
-  <a href="Referenzen/stahlbetonbau.html" class="block group" aria-label="Stahlbetonbau Referenzen">
+  <a href="leistungen.html#stahlbetonbau-details" class="block group" aria-label="Stahlbetonbau Referenzen">
   <div id="stahlbetonbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg" data-aos="fade-up" data-aos-delay="200">
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
@@ -408,7 +408,7 @@
 
 
   <!-- MAUERWERKSBAU -->
-  <a href="Referenzen/mauerwerksbau.html" class="block group" aria-label="Mauerwerksbau Referenzen">
+  <a href="leistungen.html#mauerwerksbau-details" class="block group" aria-label="Mauerwerksbau Referenzen">
   <div id="mauerwerksbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up" data-aos-delay="250">
     <img src="images/mauerwerksbau.jpg" alt="Mauerwerksbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Mauerwerksbau+Bild';" />
     <div>
@@ -436,7 +436,7 @@
 
 
   <!-- HOLZBAU -->
- <a href="Referenzen/holzbau.html" class="block group" aria-label="Holzbau Referenzen">
+ <a href="leistungen.html#holzbau-details" class="block group" aria-label="Holzbau Referenzen">
   <div id="holzbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg" data-aos="fade-up" data-aos-delay="300">
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
@@ -462,7 +462,7 @@
 
 
   <!-- STAHLBAU -->
- <a href="Referenzen/stahlbau.html" class="block group" aria-label="Stahlbau Referenzen">
+ <a href="leistungen.html#stahlbau-details" class="block group" aria-label="Stahlbau Referenzen">
   <div id="stahlbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up" data-aos-delay="350">
     <img src="images/stahlbau.jpg" alt="Stahlbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Stahlbau+Bild';" />
     <div>
@@ -488,7 +488,7 @@
 
 
    <!-- Abbruch & Rückbau -->
-  <a href="Referenzen/abbruch-und-ruckbau.html" class="block group" aria-label="Abbruch und Rückbau Referenzen">
+  <a href="leistungen.html#abbruch-und-ruckbau-details" class="block group" aria-label="Abbruch und Rückbau Referenzen">
     <div id="abbruch-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up" data-aos-delay="150">
       <img src="images/abbruch.jpg" alt="Abbruch und Rückbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Abbruch+Bild';" />
       <div>

--- a/Website/referenzen.html
+++ b/Website/referenzen.html
@@ -172,7 +172,7 @@
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10" data-aos="fade-up">
 
     <!-- Erdbau -->
-    <a href="Referenzen/erdbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="leistungen.html#erdbau-details" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="images/erdbau.jpg" alt="Erdbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -192,7 +192,7 @@
     </a>
 
     <!-- Kanalbau -->
-    <a href="Referenzen/kanalbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="leistungen.html#kanalbau-details" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="images/kanalbau.jpg" alt="Kanalbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -212,7 +212,7 @@
     </a>
 
     <!-- Stahlbetonbau -->
-    <a href="Referenzen/stahlbetonbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="leistungen.html#stahlbetonbau-details" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="images/stahlbetonbau.jpg" alt="Stahlbetonbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -232,7 +232,7 @@
     </a>
 
     <!-- Mauerwerksbau -->
-    <a href="Referenzen/mauerwerksbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="leistungen.html#mauerwerksbau-details" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="images/mauerwerksbau.jpg" alt="Mauerwerksbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -252,7 +252,7 @@
     </a>
 
     <!-- Holzbau -->
-    <a href="Referenzen/holzbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="leistungen.html#holzbau-details" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="images/holzbau.webp" alt="Holzbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -272,7 +272,7 @@
     </a>
 
     <!-- Stahlbau -->
-    <a href="Referenzen/stahlbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+    <a href="leistungen.html#stahlbau-details" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
       <div class="relative overflow-hidden">
         <img src="images/stahlbau.jpg" alt="Stahlbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
         <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
@@ -292,7 +292,7 @@
     </a>
 
     <!-- Abbruch & Rückbau -->
-<a href="Referenzen/abbruch-und-ruckbau.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+<a href="leistungen.html#abbruch-und-ruckbau-details" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
   <div class="relative overflow-hidden">
     <img src="images/abbruch.jpg" alt="Abbruch & Rückbau" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
     <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- update links to Referenzen pages with new anchor links in `leistungen.html` and `referenzen.html`

## Testing
- `grep -R "Referenzen/" -n Website`

------
https://chatgpt.com/codex/tasks/task_e_687a6850ef18832ca4c9a1976116f7ef