### PR TITLE
Update Abbruch section links

### DIFF
--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -253,7 +253,7 @@
     </a>
 
     <!-- Abbruch & Rückbau -->
-    <a href="leistungen.html#abbruch-und-ruckbau-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Abbruch & Rückbau erfahren">
+    <a href="leistungen.html#abbruch-details" class="group p-6 bg-white rounded-2xl shadow-md hover:shadow-[0_0_25px_rgba(251,187,33,0.6)] hover:-translate-y-1 transition duration-300 transform flex flex-col items-center text-center border border-gray-200 hover:bg-[var(--primary-color)] focus:outline-none focus:ring-4 focus:ring-[var(--primary-color)] focus:ring-opacity-50" tabindex="0" aria-label="Mehr über Abbruch & Rückbau erfahren">
   <div class="p-3 rounded-full bg-gradient-to-br from-white via-white to-[var(--primary-color)/20] shadow-md transition duration-300 group-hover:bg-white">
     <svg class="h-8 w-8 text-[var(--primary-color)] group-hover:scale-110 group-hover:-translate-y-1 transition-transform duration-300 ease-out"
          viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -488,7 +488,7 @@
 
 
    <!-- Abbruch & Rückbau -->
-  <a href="leistungen.html#abbruch-und-ruckbau-details" class="block group" aria-label="Abbruch und Rückbau Referenzen">
+  <a href="leistungen.html#abbruch-details" class="block group" aria-label="Abbruch und Rückbau Referenzen">
     <div id="abbruch-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up" data-aos-delay="150">
       <img src="images/abbruch.jpg" alt="Abbruch und Rückbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Abbruch+Bild';" />
       <div>


### PR DESCRIPTION
## Summary
- fix anchor links for Abbruch & Rückbau section so they reference the existing `abbruch-details` ID

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a6d0a46dc832c8148a3e1fd5f5126