### PR TITLE
Update carousel defaults and speed handling

### DIFF
--- a/Website/README.md
+++ b/Website/README.md
@@ -12,7 +12,8 @@ Professionelle Website für die Baufirma HK Bau – gebaut mit HTML, Tailwind CS
 - Slide-in Mobile Navigation
 - Animierte Counter
 - Referenzen-Karussell, das endlos automatisch scrollt und beim Wischen zentriert einrastet
-  (Tempo kann über `data-speed` am Element `#referenzen-carousel` angepasst werden)
+  (Tempo kann über `data-speed` am Element `#referenzen-carousel` angepasst werden,
+  z.B. `<div id="referenzen-carousel" data-speed="1.0">`)
 
 ## Projektstruktur
 /Website/ (enthält alle HTML-Dateien)

--- a/Website/index.html
+++ b/Website/index.html
@@ -637,7 +637,7 @@
 
 
     <!-- Continuous Scrolling Carousel -->
-   <div class="overflow-x-auto scrollbar-hide touch-pan-x snap-x snap-mandatory group" id="referenzen-carousel">
+   <div class="overflow-x-auto scrollbar-hide touch-pan-x snap-x snap-mandatory group" id="referenzen-carousel" data-speed="1.0">
 
 
 

--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -717,11 +717,9 @@ function initAnimatedCounters() {
       isDragging = false;
     });
 
-    const speed = 0.6;
-
     function autoScrollStep() {
       if (!isHovered && !isDragging) {
-        carousel.scrollLeft += speed * direction;
+        carousel.scrollLeft += currentSpeed * direction;
         if (carousel.scrollLeft >= track.scrollWidth / 2) {
           carousel.scrollLeft -= track.scrollWidth / 2;
         }


### PR DESCRIPTION
## Summary
- add `data-speed` attribute to the references carousel
- remove hard-coded speed from JS and use the `currentSpeed` variable
- document carousel speed example in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a8857f6b4832c9f56b79df612bed5