### PR TITLE
Keep overlay visible until page load

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -198,7 +198,7 @@ function setupPageTransitions() {
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
         return; // Skip transitions for reduced motion users
     }
-    let overlay = document.getElementById("pageTransitionOverlay");
+    let overlay = document.querySelector('#pageTransitionOverlay, .page-transition-overlay');
     if (!overlay) {
         overlay = document.createElement("div");
         overlay.id = "pageTransitionOverlay";
@@ -207,18 +207,27 @@ function setupPageTransitions() {
     }
 
     if (sessionStorage.getItem("isTransitioning") === "true") {
-        overlay.classList.remove("is-wiping-in");
-        overlay.classList.add("is-wiping-out");
+        Object.assign(overlay.style, {
+            opacity: "1",
+            visibility: "visible",
+            pointerEvents: "auto"
+        });
+        overlay.classList.add("is-fading-in");
 
-        overlay.addEventListener("animationend", function handler() {
-            overlay.classList.remove("is-wiping-out");
-            Object.assign(overlay.style, {
-                opacity: "0",
-                visibility: "hidden",
-                pointerEvents: "none"
-            });
-            sessionStorage.removeItem("isTransitioning");
-            overlay.removeEventListener("animationend", handler);
+        window.addEventListener("load", () => {
+            overlay.classList.remove("is-fading-in");
+            overlay.classList.add("is-fading-out");
+
+            overlay.addEventListener("transitionend", function handler() {
+                overlay.classList.remove("is-fading-out");
+                Object.assign(overlay.style, {
+                    opacity: "0",
+                    visibility: "hidden",
+                    pointerEvents: "none"
+                });
+                sessionStorage.removeItem("isTransitioning");
+                overlay.removeEventListener("transitionend", handler);
+            }, { once: true });
         }, { once: true });
     } else {
         Object.assign(overlay.style, {
@@ -244,8 +253,8 @@ function setupPageTransitions() {
                     visibility: "visible",
                     pointerEvents: "auto"
                 });
-                overlay.classList.remove("is-wiping-out");
-                overlay.classList.add("is-wiping-in");
+                overlay.classList.remove("is-fading-out");
+                overlay.classList.add("is-fading-in");
 
                 sessionStorage.setItem("isTransitioning", "true");
                 setTimeout(() => {
@@ -575,30 +584,6 @@ document.addEventListener("DOMContentLoaded", () => {
     el.textContent = new Date().getFullYear();
   });
 
-  const overlay = document.querySelector(".page-transition-overlay");
-  if (overlay) {
-    const links = document.querySelectorAll("a[href]:not(.glightbox)");
-    links.forEach(link => {
-      const href = link.getAttribute("href");
-      if (
-        !href ||
-        href.startsWith("http") ||
-        href.startsWith("mailto:") ||
-        href.startsWith("#") ||
-        href.endsWith(".pdf")
-      ) return;
-
-      link.addEventListener("click", (e) => {
-        e.preventDefault();
-        requestAnimationFrame(() => {
-          overlay.classList.add("is-fading-in");
-          setTimeout(() => {
-            window.location.href = href;
-          }, 500);
-        });
-      });
-    });
-  }
 });
 
 


### PR DESCRIPTION
## Summary
- show transition overlay until new page finishes loading
- update transition classes to use `is-fading-*`
- fix overlay query so the existing logo/text remain
- remove duplicate click handler that triggered two navigations

## Testing
- `node -e "require('./Website/js/app.js')"` *(fails: `document` is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687a97b30d74832c8a0379770dfc357d