### PR TITLE
Improve page transition overlay

### DIFF
--- a/Website/Referenzen/abbruch-und-ruckbau.html
+++ b/Website/Referenzen/abbruch-und-ruckbau.html
@@ -35,6 +35,7 @@
 
 </head>
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
   <script src="../js/app.js" defer></script>

--- a/Website/Referenzen/erdbau.html
+++ b/Website/Referenzen/erdbau.html
@@ -35,6 +35,7 @@
 
 </head>
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
   <script src="../js/app.js" defer></script>

--- a/Website/Referenzen/holzbau.html
+++ b/Website/Referenzen/holzbau.html
@@ -35,6 +35,7 @@
 
 </head>
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
   <script src="../js/app.js" defer></script>

--- a/Website/Referenzen/kanalbau.html
+++ b/Website/Referenzen/kanalbau.html
@@ -35,6 +35,7 @@
 
 </head>
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
   <script src="../js/app.js" defer></script>

--- a/Website/Referenzen/mauerwerksbau.html
+++ b/Website/Referenzen/mauerwerksbau.html
@@ -35,6 +35,7 @@
 
 </head>
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
   <script src="../js/app.js" defer></script>

--- a/Website/Referenzen/stahlbau.html
+++ b/Website/Referenzen/stahlbau.html
@@ -35,6 +35,7 @@
 
 </head>
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
   <script src="../js/app.js" defer></script>

--- a/Website/Referenzen/stahlbetonbau.html
+++ b/Website/Referenzen/stahlbetonbau.html
@@ -35,6 +35,7 @@
 
 </head>
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
   <script src="../js/app.js" defer></script>

--- a/Website/css/style.css
+++ b/Website/css/style.css
@@ -92,6 +92,14 @@ body {
   transition: opacity 0.5s ease-out, transform 0.5s ease-out;
 }
 
+.is-transitioning .page-transition-overlay {
+  opacity: 1;
+  transform: scale(1);
+  visibility: visible;
+  pointer-events: all;
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+}
+
 .page-transition-overlay.is-fading-out {
    opacity: 0;
   transform: scale(1.03);

--- a/Website/datenschutzerklaerung.html
+++ b/Website/datenschutzerklaerung.html
@@ -76,6 +76,7 @@
 
 
 <body class="font-[Inter] bg-gray-100 text-gray-900 impressum-page overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
 <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">

--- a/Website/impressum.html
+++ b/Website/impressum.html
@@ -75,6 +75,7 @@
 
 
 <body class="font-[Inter] bg-gray-100 text-gray-900 impressum-page overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
 <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">

--- a/Website/index.html
+++ b/Website/index.html
@@ -75,6 +75,7 @@
 
 
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
 
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
   <script src="js/app.js" defer></script>

--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -226,6 +226,7 @@ function setupPageTransitions() {
                     pointerEvents: "none"
                 });
                 sessionStorage.removeItem("isTransitioning");
+                document.documentElement.classList.remove("is-transitioning");
                 overlay.removeEventListener("transitionend", handler);
             }, { once: true });
         }, { once: true });

--- a/Website/karriere.html
+++ b/Website/karriere.html
@@ -116,6 +116,7 @@
 </head>
 
 <body class="text-[var(--secondary-color)] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
     
 <div id="pageTransitionOverlay" class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">

--- a/Website/kontakt.html
+++ b/Website/kontakt.html
@@ -77,6 +77,7 @@
 </head>
 
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
 
  <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">

--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -74,6 +74,7 @@
 </head>
 
 <body class="font-[Inter] text-gray-800 overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
 <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">
     <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">

--- a/Website/referenzen.html
+++ b/Website/referenzen.html
@@ -79,6 +79,7 @@
 
 
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
 
 <div class="page-transition-overlay flex items-center justify-center">
   <div class="flex flex-col items-center space-y-4 animate-fade-in">

--- a/Website/wissen.html
+++ b/Website/wissen.html
@@ -116,6 +116,7 @@
 </head>
 
 <body class="font-[Inter] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
 
   <!-- Page Transition Overlay -->
   <div class="page-transition-overlay flex items-center justify-center">


### PR DESCRIPTION
## Summary
- ensure the overlay is visible when `<html>` has `is-transitioning`
- add inline script to reapply the `is-transitioning` class on page load
- remove the `is-transitioning` class after the fade out

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687aa648ea68832cacd78c8d72b44b53