### PR TITLE
Add page transition overlay to 404 and winter article

### DIFF
--- a/Website/404.html
+++ b/Website/404.html
@@ -18,6 +18,20 @@
   <meta name="theme-color" content="#fbbb21">
 </head>
 <body class="min-h-screen flex flex-col bg-white text-gray-800 overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
+
+  <div class="page-transition-overlay flex items-center justify-center">
+    <div class="flex flex-col items-center space-y-4 animate-fade-in">
+      <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
+        <img src="images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      </div>
+      <span class="text-white text-sm tracking-wide">Lädt...</span>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
+  <script src="js/app.js" defer></script>
+
   <header class="bg-secondary-color text-white py-4">
     <div class="max-w-7xl mx-auto px-4">
       <a href="index.html" class="font-bold">HK Bau</a>
@@ -33,6 +47,5 @@
   <footer class="bg-secondary-color text-text-on-dark text-center py-4">
       <p>© <span class="current-year"></span> HK Bau GmbH</p>
   </footer>
-<script src="js/app.js" defer></script>
 </body>
 </html>

--- a/Website/wissen/betonieren-im-winter.html
+++ b/Website/wissen/betonieren-im-winter.html
@@ -67,6 +67,19 @@
 
 
 <body class="font-[Inter] text-[var(--secondary-color)] overflow-x-hidden">
+  <script>if (sessionStorage.getItem("isTransitioning") === "true") document.documentElement.classList.add("is-transitioning");</script>
+
+  <div class="page-transition-overlay flex items-center justify-center">
+    <div class="flex flex-col items-center space-y-4 animate-fade-in">
+      <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      </div>
+      <span class="text-white text-sm tracking-wide">Lädt...</span>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
+  <script src="../js/app.js" defer></script>
 
   <!-- Hero Section -->
   <section class="relative h-[60vh] flex items-center justify-center overflow-hidden parallax">


### PR DESCRIPTION
## Summary
- enable fade transitions on the 404 page
- enable fade transitions on the "Betonieren im Winter" article

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687aac58df78832c94658abdd3619d6c