### PR TITLE
Add poster to hero video and improve overlay behavior

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -145,8 +145,10 @@
     muted
     loop
     playsinline
-    preload="auto"
+    preload="none"
+    poster="images/erdbau.jpg"
     data-hero-media
+    data-load-after
     class="absolute inset-0 w-full h-full object-cover object-center -z-10">
     <source src="images/videos/hero-3.mp4" type="video/mp4" />
     Your browser does not support the video tag.

--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -218,7 +218,10 @@ function setupPageTransitions() {
 
         const heroMedia = document.querySelector('[data-hero-media]');
 
+        let overlayHidden = false;
         const hideOverlay = () => {
+            if (overlayHidden) return;
+            overlayHidden = true;
             overlay.classList.remove("is-fading-in");
             overlay.classList.add("is-fading-out");
 
@@ -237,8 +240,19 @@ function setupPageTransitions() {
 
         if (heroMedia) {
             if (heroMedia.tagName === 'VIDEO') {
-                if (heroMedia.readyState >= 3) hideOverlay();
-                else heroMedia.addEventListener('loadeddata', hideOverlay, { once: true });
+                const posterSrc = heroMedia.getAttribute('poster');
+                if (posterSrc) {
+                    const posterImg = new Image();
+                    posterImg.src = posterSrc;
+                    if (posterImg.complete) hideOverlay();
+                    else posterImg.addEventListener('load', hideOverlay, { once: true });
+                }
+
+                if (heroMedia.readyState >= 3) {
+                    hideOverlay();
+                } else {
+                    heroMedia.addEventListener('loadeddata', hideOverlay, { once: true });
+                }
             } else {
                 if (heroMedia.complete) hideOverlay();
                 else heroMedia.addEventListener('load', hideOverlay, { once: true });
@@ -280,6 +294,14 @@ function setupPageTransitions() {
             });
         }
     });
+}
+
+// ======== Delayed Hero Video Load ===========
+function loadHeroVideo() {
+    const video = document.querySelector('[data-hero-media][data-load-after]');
+    if (video) {
+        video.load();
+    }
 }
 
 // ========== Project Carousel (Autoplay, Swipe, Indicators) ============
@@ -581,6 +603,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initWirSchaffenCarousel();
   initAnimatedCounters();
   initReferenzenCarousel();
+  loadHeroVideo();
 
   document.querySelectorAll('.carousel-container').forEach(container => {
     let startX = 0;


### PR DESCRIPTION
## Summary
- set `preload="none"` and add `poster` image to hero video
- load hero video after initial page render via `loadHeroVideo`
- hide page transition overlay once poster or first frame loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ab9c248c8832c9ea360aca650a299