### PR TITLE
Fix Leistung links to go to reference pages

### DIFF
--- a/Website/leistungen.html
+++ b/Website/leistungen.html
@@ -336,7 +336,7 @@
   </div>
 
   <!-- Erdbau -->
-  <a href="#erdbau-details" class="block group" aria-label="Erdbau Referenzen">
+  <a href="Referenzen/erdbau.html" class="block group" aria-label="Erdbau Referenzen">
   <div id="erdbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up">
     <img src="images/erdbau.jpg" alt="Erdbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Erdbau+Bild';" />
     <div>
@@ -363,7 +363,7 @@
 </a>
 
 <!-- Kanalbau -->
-<a href="#kanalbau-details" class="block group" aria-label="Kanalbau Referenzen">
+<a href="Referenzen/kanalbau.html" class="block group" aria-label="Kanalbau Referenzen">
   <div id="kanalbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg" data-aos="fade-up" data-aos-delay="100">
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
@@ -390,7 +390,7 @@
  
 
  <!-- STAHLBETONBAU -->
-  <a href="#stahlbetonbau-details" class="block group" aria-label="Stahlbetonbau Referenzen">
+  <a href="Referenzen/stahlbetonbau.html" class="block group" aria-label="Stahlbetonbau Referenzen">
   <div id="stahlbetonbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg" data-aos="fade-up" data-aos-delay="200">
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
@@ -418,7 +418,7 @@
 
 
   <!-- MAUERWERKSBAU -->
-  <a href="#mauerwerksbau-details" class="block group" aria-label="Mauerwerksbau Referenzen">
+  <a href="Referenzen/mauerwerksbau.html" class="block group" aria-label="Mauerwerksbau Referenzen">
   <div id="mauerwerksbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up" data-aos-delay="250">
     <img src="images/mauerwerksbau.jpg" alt="Mauerwerksbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Mauerwerksbau+Bild';" />
     <div>
@@ -446,7 +446,7 @@
 
 
   <!-- HOLZBAU -->
- <a href="#holzbau-details" class="block group" aria-label="Holzbau Referenzen">
+ <a href="Referenzen/holzbau.html" class="block group" aria-label="Holzbau Referenzen">
   <div id="holzbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 even:bg-light-bg" data-aos="fade-up" data-aos-delay="300">
     <div>
       <h3 class="text-3xl lg:text-4xl font-bold mb-4 text-secondary-color flex items-center gap-2">
@@ -472,7 +472,7 @@
 
 
   <!-- STAHLBAU -->
- <a href="#stahlbau-details" class="block group" aria-label="Stahlbau Referenzen">
+ <a href="Referenzen/stahlbau.html" class="block group" aria-label="Stahlbau Referenzen">
   <div id="stahlbau-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up" data-aos-delay="350">
     <img src="images/stahlbau.jpg" alt="Stahlbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Stahlbau+Bild';" />
     <div>
@@ -499,7 +499,7 @@
 
    <!-- Abbruch & Rückbau -->
 
-  <a href="leistungen.html#abbruch-details" class="block group" aria-label="Abbruch und Rückbau Referenzen">
+  <a href="Referenzen/abbruch-und-ruckbau.html" class="block group" aria-label="Abbruch und Rückbau Referenzen">
 
     <div id="abbruch-details" class="grid md:grid-cols-2 gap-10 items-center bg-white p-10 rounded-3xl shadow-xl transition duration-300 odd:bg-light-bg" data-aos="fade-up" data-aos-delay="150">
       <img src="images/abbruch.webp" alt="Abbruch und Rückbau" loading="lazy" class="rounded-xl w-full h-72 object-cover shadow-lg group-hover:scale-[1.02] transition duration-300" onerror="this.onerror=null;this.src='https://via.placeholder.com/700x480?text=Abbruch+Bild';" />


### PR DESCRIPTION
## Summary
- link each card in the "Leistungen im Detail" section directly to its reference page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b2fe83e64832c97448d52c289e3e1