### PR TITLE
Fix carousel arrow placement

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -640,18 +640,16 @@
 
 
 
+    <!-- Carousel Navigation Buttons -->
+    <button id="carousel-prev" class="carousel-prev-btn carousel-prev absolute left-0 top-1/2 -translate-y-1/2 z-20 bg-white rounded-full shadow p-2 hover:scale-110 transition">
+      ‹
+    </button>
+    <button id="carousel-next" class="carousel-next-btn carousel-next absolute right-0 top-1/2 -translate-y-1/2 z-20 bg-white rounded-full shadow p-2 hover:scale-110 transition">
+      ›
+    </button>
+
     <!-- Continuous Scrolling Carousel -->
    <div class="overflow-x-auto scrollbar-hide touch-pan-x snap-x snap-mandatory group" id="referenzen-carousel" data-speed="1.0">
-
-
-
-<!-- Carousel Navigation Buttons -->
-<button id="carousel-prev" class="carousel-prev absolute left-0 top-1/2 -translate-y-1/2 z-20 bg-white rounded-full shadow p-2 hover:scale-110 transition">
-  ‹
-</button>
-<button id="carousel-next" class="carousel-next absolute right-0 top-1/2 -translate-y-1/2 z-20 bg-white rounded-full shadow p-2 hover:scale-110 transition">
-  ›
-</button>
 
 
       <div class="flex gap-8 w-max px-4 sm:px-6 lg:px-8 transition-transform duration-700 ease-linear" id="referenzen-track">


### PR DESCRIPTION
## Summary
- move carousel navigation buttons out of the scrolling element
- apply shared styling classes for arrow buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687b45f2a294832c8438759cbd50d296