### PR TITLE
Fix touch drag prevention for references carousel

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -746,6 +746,7 @@ function initAnimatedCounters() {
 
     carousel.addEventListener('touchmove', (e) => {
       if (!isDragging) return;
+      e.preventDefault();
       const deltaX = startX - e.touches[0].clientX;
       carousel.scrollLeft = startScroll + deltaX;
     });


### PR DESCRIPTION
## Summary
- stop default page scrolling while dragging the Referenzen carousel

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b487165d0832ca49d906b2df09ec2