### PR TITLE
Fix overlay caching issue on back navigation

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -206,6 +206,27 @@ function setupPageTransitions() {
         document.body.appendChild(overlay);
     }
 
+    window.addEventListener('pageshow', () => {
+        if (sessionStorage.getItem('isTransitioning') !== 'true') {
+            overlay.classList.remove('is-fading-in', 'is-fading-out');
+            Object.assign(overlay.style, {
+                opacity: '0',
+                visibility: 'hidden',
+                pointerEvents: 'none'
+            });
+            document.documentElement.classList.remove('is-transitioning');
+        }
+    });
+
+    window.addEventListener('pagehide', () => {
+        overlay.classList.remove('is-fading-in', 'is-fading-out');
+        Object.assign(overlay.style, {
+            opacity: '0',
+            visibility: 'hidden',
+            pointerEvents: 'none'
+        });
+    });
+
     if (sessionStorage.getItem("isTransitioning") === "true") {
         Object.assign(overlay.style, {
             opacity: "1",


### PR DESCRIPTION
## Summary
- avoid persisting overlay when pages are cached
- hide overlay on pagehide and cleanup on pageshow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687de7f550cc832c9e06a98d8cd13d4e