### PR TITLE
Fix trailing space in image path

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -741,7 +741,7 @@
 
          <!-- Sindelfingen -->
         <div class="relative w-[26rem] h-[17rem] snap-center overflow-hidden rounded-lg">
-          <img src="images/projekten/10-neubau-mfh-8-we-tg-sindelfingen.JPG " alt="Neubau MFH in Sindelfingen 2" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700"  loading="lazy" />
+          <img src="images/projekten/10-neubau-mfh-8-we-tg-sindelfingen.JPG" alt="Neubau MFH in Sindelfingen 2" class="carousel-image w-full h-full object-cover rounded-lg shadow transition-transform duration-700"  loading="lazy" />
           <div class="carousel-caption absolute bottom-0 left-0 right-0 w-full bg-black/80 backdrop-blur-sm text-white text-base sm:text-lg text-center p-2">Neubau MFH in Sindelfingen</div>
         </div>
 


### PR DESCRIPTION
## Summary
- fix reference carousel image path in `index.html`

## Testing
- `test -f Website/images/projekten/10-neubau-mfh-8-we-tg-sindelfingen.JPG`


------
https://chatgpt.com/codex/tasks/task_e_687e2c3ccbec832cad0745a20afdaeb1