### PR TITLE
Fix touchmove handling for referenzen carousel

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -786,12 +786,14 @@ if (nextBtn) {
       startScroll = carousel.scrollLeft;
     });
 
-    carousel.addEventListener('touchmove', (e) => {
+    function onMove(e) {
       if (!isDragging) return;
       e.preventDefault();
       const deltaX = startX - e.touches[0].clientX;
       carousel.scrollLeft = startScroll + deltaX;
-    });
+    }
+
+    carousel.addEventListener('touchmove', onMove, { passive: false });
 
     carousel.addEventListener('touchend', () => {
       isDragging = false;


### PR DESCRIPTION
## Summary
- ensure preventDefault works on the Referenzen carousel by using passive:false

## Testing
- `node --check Website/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_687e2c47da88832c80f38e097f7b32ac