### PR TITLE
Unify Referenzen subpages layout

### DIFF
--- a/Website/Referenzen/abbruch-und-ruckbau.html
+++ b/Website/Referenzen/abbruch-und-ruckbau.html
@@ -95,16 +95,22 @@
 
 
   <main>
-  <section class="relative h-[100vh] md:h-[600px] flex items-center justify-center overflow-hidden">
-    <img src="../images/erdbau.jpg" alt="Abbruch &amp; Rückbau" class="absolute inset-0 w-full h-full object-cover -z-10" data-hero-media />
-    <div class="absolute inset-0 bg-black/50"></div>
-    <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white" data-aos="zoom-in">Abbruch &amp; Rückbau</h1>
-    <p class="relative z-10 text-lg md:text-xl text-white mt-4" data-aos="zoom-in" data-aos-delay="150">Kontrollierte Rückbauarbeiten für neue Perspektiven.</p>
-  </section>
+<section class="relative h-[90vh] md:h-[600px] flex items-center justify-center overflow-hidden text-white">
+  <img src="../images/erdbau.jpg" alt="Abbruch &amp; Rückbau" class="absolute inset-0 w-full h-full object-cover z-[-1]" data-hero-media />
+  <div class="absolute inset-0 bg-gradient-to-br from-black/20 via-black/60 to-black/80 z-0"></div>
+  <div class="relative z-10 text-center px-6 max-w-3xl" data-aos="zoom-in">
+    <h1 class="text-4xl md:text-5xl font-extrabold mb-4 drop-shadow-md text-[var(--primary-color)]">
+      Abbruch &amp; Rückbau
+    </h1>
+    <p class="text-lg md:text-xl opacity-90 leading-relaxed">
+      Kontrollierte Rückbauarbeiten für neue Perspektiven.
+    </p>
+  </div>
+</section>
 <section class="w-full py-20 bg-gray-50 fade-parallax">
   <div class="px-4 sm:px-6 lg:px-8 mb-10">
     <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">
-      Startseite > Referenzen > Abbruch &amp; Rückbau
+      &larr; Zurück zur Übersicht
     </a>
     <hr class="mt-4 border-t border-gray-300/50 w-24">
   </div>
@@ -140,9 +146,6 @@
     <a href="../images/referenzen/abbruch/abbruch10.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="500" aria-label="Abbruch &amp; Rückbau Projekt 10">
       <img src="../images/referenzen/abbruch/abbruch10.jpg" alt="Abbruch &amp; Rückbau 10" loading="lazy" class="w-full h-auto" />
     </a>
-  </div>
-  <div class="text-center mt-12">
-    <a href="../referenzen.html" class="inline-block bg-primary-color text-secondary-color font-semibold py-3 px-8 rounded-lg transition transform hover:scale-110">Zurück zur Übersicht</a>
   </div>
 </section>
 

--- a/Website/Referenzen/aussenanlagen.html
+++ b/Website/Referenzen/aussenanlagen.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Recommended favicon links -->
+  <link rel="icon" type="image/png" href="../favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="shortcut icon" href="../favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+  <meta name="apple-mobile-web-app-title" content="HK Bau" />
+  <link rel="manifest" href="../site.webmanifest" />
+  <title>Außenanlagen Projekte</title>
+  <meta name="description" content="Referenzen und Projektbeispiele im Bereich Außenanlagen von HK Bau GmbH in Stuttgart und Umgebung" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css" />
+  <link rel="stylesheet" href="../css/style.css" />
+
+
+<!-- Open Graph / Facebook -->
+<meta property="og:title" content="Außenanlagen Projekte | HK Bau GmbH" />
+<meta property="og:description" content="Einblicke in unsere abgeschlossenen Außenanlagen-Projekte." />
+<meta property="og:image" content="https://hkbau.de/images/erdbau.jpg" />
+<meta property="og:url" content="https://hkbau.de/referenzen/aussenanlagen.html" />
+
+<!-- Twitter Card -->
+<meta name="twitter:title" content="Außenanlagen Projekte | HK Bau GmbH" />
+<meta name="twitter:description" content="Außenanlagen aus unserer Referenzgalerie – HK Bau GmbH." />
+<meta name="twitter:image" content="https://hkbau.de/images/erdbau.jpg" />
+<meta name="twitter:card" content="summary_large_image" />
+
+
+</head>
+<body class="font-[Poppins] overflow-x-hidden">
+  <script src="../js/init-transition.js"></script>
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+  <script src="../js/app.js" defer></script>
+  <div class="page-transition-overlay flex items-center justify-center">
+    <div class="flex flex-col items-center space-y-4">
+      <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      </div>
+      <span class="text-white text-sm tracking-wide">Lädt...</span>
+    </div>
+  </div>
+
+
+<header class="fixed top-0 left-0 w-full z-30 transition duration-300" id="navbar">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+    <div class="logo-container">
+      <a href="../index.html" class="flex items-center relative z-20">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow logo" width="64" height="64" />
+        <span class="text-white font-bold ml-2">HK Bau</span>
+      </a>
+    </div>
+    <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium">
+      <a href="../index.html">Startseite</a>
+      <a href="../leistungen.html">Leistungen</a>
+      <a href="../referenzen.html">Referenzen</a>
+      <!-- <a href="wissen.html">Wissen</a> -->
+      <a href="../karriere.html">Karriere</a>
+      <a href="../kontakt.html">Kontakt</a>
+    </nav>
+
+    <!-- Hamburger Menu Button -->
+    <button id="mobile-menu-button"
+            class="md:hidden z-[100] p-2 focus:outline-none"
+            aria-label="Menü öffnen"
+            aria-expanded="false">
+      <svg class="h-6 w-6 fill-current text-white" viewBox="0 0 24 24">
+        <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Backdrop Overlay -->
+  <div id="nav-backdrop"
+       class="fixed inset-0 bg-black/70 z-[98] hidden transition-opacity duration-300"></div>
+
+  <!-- Mobile Menu -->
+  <div id="mobile-menu" class="hidden fixed top-0 left-0 w-full bg-[var(--secondary-color)] text-white z-[99] p-6">
+    <a href="../index.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Startseite</a>
+    <a href="../leistungen.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Leistungen</a>
+    <a href="../referenzen.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Referenzen</a>
+    <a href="../karriere.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Karriere</a>
+    <a href="../kontakt.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Kontakt</a>
+  </div>
+</header>
+
+
+
+
+  <main>
+<section class="relative h-[90vh] md:h-[600px] flex items-center justify-center overflow-hidden text-white">
+  <img src="../images/stahlbau.jpg" alt="Außenanlagen" class="absolute inset-0 w-full h-full object-cover z-[-1]" data-hero-media />
+  <div class="absolute inset-0 bg-gradient-to-br from-black/20 via-black/60 to-black/80 z-0"></div>
+  <div class="relative z-10 text-center px-6 max-w-3xl" data-aos="zoom-in">
+    <h1 class="text-4xl md:text-5xl font-extrabold mb-4 drop-shadow-md text-[var(--primary-color)]">
+      Außenanlagen Projekte
+    </h1>
+    <p class="text-lg md:text-xl opacity-90 leading-relaxed">
+      Individuelle Gestaltung von Außenanlagen und Freiflächen.
+    </p>
+  </div>
+</section>
+<section class="w-full py-20 bg-gray-50 fade-parallax">
+  <div class="px-4 sm:px-6 lg:px-8 mb-10">
+    <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">
+      &larr; Zurück zur Übersicht
+    </a>
+    <hr class="mt-4 border-t border-gray-300/50 w-24">
+  </div>
+
+  <div class="columns-1 sm:columns-2 lg:columns-3 gap-4 gallery px-4 sm:px-6 lg:px-8" data-aos="fade-up">
+    <a href="../images/hero-leistungen.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="50" aria-label="Außenanlagen Projekt 1">
+      <img src="../images/hero-leistungen.jpg" loading="lazy" alt="Außenanlagen 1"  class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="100" aria-label="Außenanlagen Projekt 2">
+      <img src="../images/stahlbau.jpg" alt="Außenanlagen 2" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/holzbau.webp" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="150" aria-label="Außenanlagen Projekt 3">
+      <img src="../images/holzbau.webp" alt="Außenanlagen 3" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/kanalbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="200" aria-label="Außenanlagen Projekt 4">
+      <img src="../images/kanalbau.jpg" alt="Außenanlagen 4" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/mauerwerksbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="250" aria-label="Außenanlagen Projekt 5">
+      <img src="../images/mauerwerksbau.jpg" alt="Außenanlagen 5" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/pexels-kawserhamid-176342.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="300" aria-label="Außenanlagen Projekt 6">
+      <img src="../images/pexels-kawserhamid-176342.jpg" alt="Außenanlagen 6" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/pexels-yury-kim-181374-585418.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="350" aria-label="Außenanlagen Projekt 7">
+      <img src="../images/pexels-yury-kim-181374-585418.jpg" alt="Außenanlagen 7" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="400" aria-label="Außenanlagen Projekt 8">
+      <img src="../images/stahlbau.jpg" alt="Außenanlagen 8" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbetonbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="450" aria-label="Außenanlagen Projekt 9">
+      <img src="../images/stahlbetonbau.jpg" alt="Außenanlagen 9" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/unsere_strategie_2.png" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="500" aria-label="Außenanlagen Projekt 10">
+      <img src="../images/unsere_strategie_2.png" alt="Außenanlagen 10" loading="lazy" class="w-full h-auto" />
+    </a>
+  </div>
+</section>
+
+
+
+  </main>
+  <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
+    <div class="space-y-4">
+      <nav class="space-x-4">
+        <a href="../index.html">Startseite</a>
+        <a href="../leistungen.html">Leistungen</a>
+        <a href="../referenzen.html">Referenzen</a>
+        <!-- <a href="../wissen.html">Wissen</a> -->
+        <a href="../karriere.html">Karriere</a>
+        <a href="../kontakt.html">Kontakt</a>
+      </nav>
+      <div class="flex justify-center space-x-6 text-xl mt-4">
+        <a href="https://www.facebook.com/people/HK-Bauunternehmung-GmbH/100087217129678/" target="_blank" aria-label="Facebook">
+          <i aria-hidden="true" class="fab fa-facebook-f"></i>
+        </a>
+        <a href="https://www.instagram.com/hk.bau/" target="_blank" aria-label="Instagram">
+          <i aria-hidden="true" class="fab fa-instagram"></i>
+        </a>
+        <a href="https://www.linkedin.com" target="_blank" aria-label="LinkedIn">
+          <i aria-hidden="true" class="fab fa-linkedin-in"></i>
+        </a>
+      </div>
+      <p>© <span class="current-year"></span> HK Bau GmbH. Alle Rechte vorbehalten.</p>
+      <p class="text-xs">
+        <a href="../impressum.html">Impressum</a> | <a href="../datenschutzerklaerung.html">Datenschutz</a>
+      </p>
+    </div>
+  </footer>
+  <button id="scrollToTopBtn" class="hidden fixed bottom-6 right-6 bg-primary-color text-secondary-color p-3 rounded-full shadow-lg hover:bg-primary-hover transition" aria-label="Nach oben scrollen">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
+    </svg>
+  </button>
+  <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
+</body>
+</html>

--- a/Website/Referenzen/dachdeckung-und-dachabdichtung.html
+++ b/Website/Referenzen/dachdeckung-und-dachabdichtung.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Recommended favicon links -->
+  <link rel="icon" type="image/png" href="../favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="shortcut icon" href="../favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+  <meta name="apple-mobile-web-app-title" content="HK Bau" />
+  <link rel="manifest" href="../site.webmanifest" />
+  <title>Dachdeckung & Dachabdichtung Projekte</title>
+  <meta name="description" content="Referenzen und Projektbeispiele im Bereich Dachdeckung & Dachabdichtung von HK Bau GmbH in Stuttgart und Umgebung" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css" />
+  <link rel="stylesheet" href="../css/style.css" />
+
+
+<!-- Open Graph / Facebook -->
+<meta property="og:title" content="Dachdeckung & Dachabdichtung Projekte | HK Bau GmbH" />
+<meta property="og:description" content="Einblicke in unsere abgeschlossenen Dach-Projekte." />
+<meta property="og:image" content="https://hkbau.de/images/erdbau.jpg" />
+<meta property="og:url" content="https://hkbau.de/referenzen/dachdeckung-und-dachabdichtung.html" />
+
+<!-- Twitter Card -->
+<meta name="twitter:title" content="Dachdeckung & Dachabdichtung Projekte | HK Bau GmbH" />
+<meta name="twitter:description" content="Dacharbeiten aus unserer Referenzgalerie – HK Bau GmbH." />
+<meta name="twitter:image" content="https://hkbau.de/images/erdbau.jpg" />
+<meta name="twitter:card" content="summary_large_image" />
+
+
+</head>
+<body class="font-[Poppins] overflow-x-hidden">
+  <script src="../js/init-transition.js"></script>
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+  <script src="../js/app.js" defer></script>
+  <div class="page-transition-overlay flex items-center justify-center">
+    <div class="flex flex-col items-center space-y-4">
+      <div class="h-20 w-20 rounded-full bg-white border-4 border-[var(--primary-color)] flex items-center justify-center shadow-lg">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-12 w-12 animate-spin-slower" />
+      </div>
+      <span class="text-white text-sm tracking-wide">Lädt...</span>
+    </div>
+  </div>
+
+
+<header class="fixed top-0 left-0 w-full z-30 transition duration-300" id="navbar">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+    <div class="logo-container">
+      <a href="../index.html" class="flex items-center relative z-20">
+        <img src="../images/icon/logo.png" alt="HK Bau Logo" class="h-16 w-auto rounded-full shadow logo" width="64" height="64" />
+        <span class="text-white font-bold ml-2">HK Bau</span>
+      </a>
+    </div>
+    <nav aria-label="Hauptnavigation" class="hidden md:flex space-x-8 font-medium">
+      <a href="../index.html">Startseite</a>
+      <a href="../leistungen.html">Leistungen</a>
+      <a href="../referenzen.html">Referenzen</a>
+      <!-- <a href="wissen.html">Wissen</a> -->
+      <a href="../karriere.html">Karriere</a>
+      <a href="../kontakt.html">Kontakt</a>
+    </nav>
+
+    <!-- Hamburger Menu Button -->
+    <button id="mobile-menu-button"
+            class="md:hidden z-[100] p-2 focus:outline-none"
+            aria-label="Menü öffnen"
+            aria-expanded="false">
+      <svg class="h-6 w-6 fill-current text-white" viewBox="0 0 24 24">
+        <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Backdrop Overlay -->
+  <div id="nav-backdrop"
+       class="fixed inset-0 bg-black/70 z-[98] hidden transition-opacity duration-300"></div>
+
+  <!-- Mobile Menu -->
+  <div id="mobile-menu" class="hidden fixed top-0 left-0 w-full bg-[var(--secondary-color)] text-white z-[99] p-6">
+    <a href="../index.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Startseite</a>
+    <a href="../leistungen.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Leistungen</a>
+    <a href="../referenzen.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Referenzen</a>
+    <a href="../karriere.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Karriere</a>
+    <a href="../kontakt.html" class="block py-2 px-3 text-base font-medium hover:text-[var(--primary-color)]">Kontakt</a>
+  </div>
+</header>
+
+
+
+
+  <main>
+<section class="relative h-[90vh] md:h-[600px] flex items-center justify-center overflow-hidden text-white">
+  <img src="../images/stahlbau.jpg" alt="Dachdeckung & Dachabdichtung" class="absolute inset-0 w-full h-full object-cover z-[-1]" data-hero-media />
+  <div class="absolute inset-0 bg-gradient-to-br from-black/20 via-black/60 to-black/80 z-0"></div>
+  <div class="relative z-10 text-center px-6 max-w-3xl" data-aos="zoom-in">
+    <h1 class="text-4xl md:text-5xl font-extrabold mb-4 drop-shadow-md text-[var(--primary-color)]">
+      Dachdeckung & Dachabdichtung Projekte
+    </h1>
+    <p class="text-lg md:text-xl opacity-90 leading-relaxed">
+      Zuverlässige Dachlösungen für Neu- und Bestandsbauten.
+    </p>
+  </div>
+</section>
+<section class="w-full py-20 bg-gray-50 fade-parallax">
+  <div class="px-4 sm:px-6 lg:px-8 mb-10">
+    <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">
+      &larr; Zurück zur Übersicht
+    </a>
+    <hr class="mt-4 border-t border-gray-300/50 w-24">
+  </div>
+
+  <div class="columns-1 sm:columns-2 lg:columns-3 gap-4 gallery px-4 sm:px-6 lg:px-8" data-aos="fade-up">
+    <a href="../images/hero-leistungen.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="50" aria-label="Dachdeckung & Dachabdichtung Projekt 1">
+      <img src="../images/hero-leistungen.jpg" loading="lazy" alt="Dachdeckung & Dachabdichtung 1"  class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="100" aria-label="Dachdeckung & Dachabdichtung Projekt 2">
+      <img src="../images/stahlbau.jpg" alt="Dachdeckung & Dachabdichtung 2" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/holzbau.webp" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="150" aria-label="Dachdeckung & Dachabdichtung Projekt 3">
+      <img src="../images/holzbau.webp" alt="Dachdeckung & Dachabdichtung 3" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/kanalbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="200" aria-label="Dachdeckung & Dachabdichtung Projekt 4">
+      <img src="../images/kanalbau.jpg" alt="Dachdeckung & Dachabdichtung 4" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/mauerwerksbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="250" aria-label="Dachdeckung & Dachabdichtung Projekt 5">
+      <img src="../images/mauerwerksbau.jpg" alt="Dachdeckung & Dachabdichtung 5" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/pexels-kawserhamid-176342.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="300" aria-label="Dachdeckung & Dachabdichtung Projekt 6">
+      <img src="../images/pexels-kawserhamid-176342.jpg" alt="Dachdeckung & Dachabdichtung 6" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/pexels-yury-kim-181374-585418.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="350" aria-label="Dachdeckung & Dachabdichtung Projekt 7">
+      <img src="../images/pexels-yury-kim-181374-585418.jpg" alt="Dachdeckung & Dachabdichtung 7" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="400" aria-label="Dachdeckung & Dachabdichtung Projekt 8">
+      <img src="../images/stahlbau.jpg" alt="Dachdeckung & Dachabdichtung 8" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/stahlbetonbau.jpg" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="450" aria-label="Dachdeckung & Dachabdichtung Projekt 9">
+      <img src="../images/stahlbetonbau.jpg" alt="Dachdeckung & Dachabdichtung 9" loading="lazy" class="w-full h-auto" />
+    </a>
+    <a href="../images/unsere_strategie_2.png" class="glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10" data-aos="zoom-in" data-aos-delay="500" aria-label="Dachdeckung & Dachabdichtung Projekt 10">
+      <img src="../images/unsere_strategie_2.png" alt="Dachdeckung & Dachabdichtung 10" loading="lazy" class="w-full h-auto" />
+    </a>
+  </div>
+</section>
+
+
+
+  </main>
+  <footer class="bg-secondary-color text-text-on-dark py-10 text-center" data-aos="fade-in">
+    <div class="space-y-4">
+      <nav class="space-x-4">
+        <a href="../index.html">Startseite</a>
+        <a href="../leistungen.html">Leistungen</a>
+        <a href="../referenzen.html">Referenzen</a>
+        <!-- <a href="../wissen.html">Wissen</a> -->
+        <a href="../karriere.html">Karriere</a>
+        <a href="../kontakt.html">Kontakt</a>
+      </nav>
+      <div class="flex justify-center space-x-6 text-xl mt-4">
+        <a href="https://www.facebook.com/people/HK-Bauunternehmung-GmbH/100087217129678/" target="_blank" aria-label="Facebook">
+          <i aria-hidden="true" class="fab fa-facebook-f"></i>
+        </a>
+        <a href="https://www.instagram.com/hk.bau/" target="_blank" aria-label="Instagram">
+          <i aria-hidden="true" class="fab fa-instagram"></i>
+        </a>
+        <a href="https://www.linkedin.com" target="_blank" aria-label="LinkedIn">
+          <i aria-hidden="true" class="fab fa-linkedin-in"></i>
+        </a>
+      </div>
+      <p>© <span class="current-year"></span> HK Bau GmbH. Alle Rechte vorbehalten.</p>
+      <p class="text-xs">
+        <a href="../impressum.html">Impressum</a> | <a href="../datenschutzerklaerung.html">Datenschutz</a>
+      </p>
+    </div>
+  </footer>
+  <button id="scrollToTopBtn" class="hidden fixed bottom-6 right-6 bg-primary-color text-secondary-color p-3 rounded-full shadow-lg hover:bg-primary-hover transition" aria-label="Nach oben scrollen">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
+    </svg>
+  </button>
+  <div id="nav-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden md:hidden"></div>
+</body>
+</html>

--- a/Website/Referenzen/holzbau.html
+++ b/Website/Referenzen/holzbau.html
@@ -95,11 +95,18 @@
 
 
   <main>
-  <section class="relative h-[100vh] md:h-[600px] flex items-center justify-center overflow-hidden">
-    <img src="../images/erdbau.jpg" alt="Holzbau" class="absolute inset-0 w-full h-full object-cover -z-10" data-hero-media />
-    <div class="absolute inset-0 bg-black/50"></div>
-    <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white" data-aos="zoom-in">Holzbau Projekte</h1>
-  </section>
+<section class="relative h-[90vh] md:h-[600px] flex items-center justify-center overflow-hidden text-white">
+  <img src="../images/erdbau.jpg" alt="Holzbau" class="absolute inset-0 w-full h-full object-cover z-[-1]" data-hero-media />
+  <div class="absolute inset-0 bg-gradient-to-br from-black/20 via-black/60 to-black/80 z-0"></div>
+  <div class="relative z-10 text-center px-6 max-w-3xl" data-aos="zoom-in">
+    <h1 class="text-4xl md:text-5xl font-extrabold mb-4 drop-shadow-md text-[var(--primary-color)]">
+      Holzbau Projekte
+    </h1>
+    <p class="text-lg md:text-xl opacity-90 leading-relaxed">
+      Nachhaltige Holzkonstruktionen für moderne Gebäude.
+    </p>
+  </div>
+</section>
 <section class="w-full py-20 bg-gray-50 fade-parallax">
   <div class="px-4 sm:px-6 lg:px-8 mb-10">
     <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">

--- a/Website/Referenzen/kanalbau.html
+++ b/Website/Referenzen/kanalbau.html
@@ -96,11 +96,18 @@
 
 
   <main>
-  <section class="relative h-[100vh] md:h-[600px] flex items-center justify-center overflow-hidden">
-    <img src="../images/erdbau.jpg" alt="Kanalbau" class="absolute inset-0 w-full h-full object-cover -z-10" data-hero-media />
-    <div class="absolute inset-0 bg-black/50"></div>
-    <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white" data-aos="zoom-in">Kanalbau Projekte</h1>
-  </section>
+<section class="relative h-[90vh] md:h-[600px] flex items-center justify-center overflow-hidden text-white">
+  <img src="../images/erdbau.jpg" alt="Kanalbau" class="absolute inset-0 w-full h-full object-cover z-[-1]" data-hero-media />
+  <div class="absolute inset-0 bg-gradient-to-br from-black/20 via-black/60 to-black/80 z-0"></div>
+  <div class="relative z-10 text-center px-6 max-w-3xl" data-aos="zoom-in">
+    <h1 class="text-4xl md:text-5xl font-extrabold mb-4 drop-shadow-md text-[var(--primary-color)]">
+      Kanalbau Projekte
+    </h1>
+    <p class="text-lg md:text-xl opacity-90 leading-relaxed">
+      Leistungsstarke Kanalbaulösungen für sichere Entwässerung.
+    </p>
+  </div>
+</section>
 <section class="w-full py-20 bg-gray-50 fade-parallax">
   <div class="px-4 sm:px-6 lg:px-8 mb-10">
     <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">

--- a/Website/Referenzen/mauerwerksbau.html
+++ b/Website/Referenzen/mauerwerksbau.html
@@ -96,11 +96,18 @@
 
 
   <main>
-  <section class="relative h-[100vh] md:h-[600px] flex items-center justify-center overflow-hidden">
-    <img src="../images/mauerwerksbau.jpg" alt="Mauerwerksbau" class="absolute inset-0 w-full h-full object-cover -z-10" data-hero-media />
-    <div class="absolute inset-0 bg-black/50"></div>
-    <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white" data-aos="zoom-in">Mauerwerksbau Projekte</h1>
-  </section>
+<section class="relative h-[90vh] md:h-[600px] flex items-center justify-center overflow-hidden text-white">
+  <img src="../images/mauerwerksbau.jpg" alt="Mauerwerksbau" class="absolute inset-0 w-full h-full object-cover z-[-1]" data-hero-media />
+  <div class="absolute inset-0 bg-gradient-to-br from-black/20 via-black/60 to-black/80 z-0"></div>
+  <div class="relative z-10 text-center px-6 max-w-3xl" data-aos="zoom-in">
+    <h1 class="text-4xl md:text-5xl font-extrabold mb-4 drop-shadow-md text-[var(--primary-color)]">
+      Mauerwerksbau Projekte
+    </h1>
+    <p class="text-lg md:text-xl opacity-90 leading-relaxed">
+      Massives Mauerwerk für langlebige Gebäude.
+    </p>
+  </div>
+</section>
 <section class="w-full py-20 bg-gray-50 fade-parallax">
   <div class="px-4 sm:px-6 lg:px-8 mb-10">
     <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">

--- a/Website/Referenzen/stahlbau.html
+++ b/Website/Referenzen/stahlbau.html
@@ -95,11 +95,18 @@
 
 
   <main>
-  <section class="relative h-[100vh] md:h-[600px] flex items-center justify-center overflow-hidden">
-    <img src="../images/stahlbau.jpg" alt="Stahlbau" class="absolute inset-0 w-full h-full object-cover -z-10" data-hero-media />
-    <div class="absolute inset-0 bg-black/50"></div>
-    <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white" data-aos="zoom-in">Stahlbau Projekte</h1>
-  </section>
+<section class="relative h-[90vh] md:h-[600px] flex items-center justify-center overflow-hidden text-white">
+  <img src="../images/stahlbau.jpg" alt="Stahlbau" class="absolute inset-0 w-full h-full object-cover z-[-1]" data-hero-media />
+  <div class="absolute inset-0 bg-gradient-to-br from-black/20 via-black/60 to-black/80 z-0"></div>
+  <div class="relative z-10 text-center px-6 max-w-3xl" data-aos="zoom-in">
+    <h1 class="text-4xl md:text-5xl font-extrabold mb-4 drop-shadow-md text-[var(--primary-color)]">
+      Stahlbau Projekte
+    </h1>
+    <p class="text-lg md:text-xl opacity-90 leading-relaxed">
+      Präzise Stahlkonstruktionen für Industrie und Gewerbe.
+    </p>
+  </div>
+</section>
 <section class="w-full py-20 bg-gray-50 fade-parallax">
   <div class="px-4 sm:px-6 lg:px-8 mb-10">
     <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">

--- a/Website/Referenzen/stahlbetonbau.html
+++ b/Website/Referenzen/stahlbetonbau.html
@@ -95,11 +95,18 @@
 
 
   <main>
-  <section class="relative h-[100vh] md:h-[600px] flex items-center justify-center overflow-hidden">
-    <img src="../images/erdbau.jpg" alt="Stahlbetonbau" class="absolute inset-0 w-full h-full object-cover -z-10" data-hero-media />
-    <div class="absolute inset-0 bg-black/50"></div>
-    <h1 class="relative z-10 text-4xl md:text-6xl font-bold text-white" data-aos="zoom-in">Stahlbetonbau Projekte</h1>
-  </section>
+<section class="relative h-[90vh] md:h-[600px] flex items-center justify-center overflow-hidden text-white">
+  <img src="../images/erdbau.jpg" alt="Stahlbetonbau" class="absolute inset-0 w-full h-full object-cover z-[-1]" data-hero-media />
+  <div class="absolute inset-0 bg-gradient-to-br from-black/20 via-black/60 to-black/80 z-0"></div>
+  <div class="relative z-10 text-center px-6 max-w-3xl" data-aos="zoom-in">
+    <h1 class="text-4xl md:text-5xl font-extrabold mb-4 drop-shadow-md text-[var(--primary-color)]">
+      Stahlbetonbau Projekte
+    </h1>
+    <p class="text-lg md:text-xl opacity-90 leading-relaxed">
+      Robuste Konstruktionen aus Beton und Stahl.
+    </p>
+  </div>
+</section>
 <section class="w-full py-20 bg-gray-50 fade-parallax">
   <div class="px-4 sm:px-6 lg:px-8 mb-10">
     <a href="../referenzen.html" class="inline-block text-[var(--primary-color)] hover:underline font-semibold text-lg" aria-label="Zurück zur Übersicht">

--- a/Website/referenzen.html
+++ b/Website/referenzen.html
@@ -309,6 +309,45 @@
 </a>
 
 
+    <!-- Au\xC3\x9Fenanlagen -->
+    <a href="Referenzen/aussenanlagen.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+      <div class="relative overflow-hidden">
+        <img src="images/holzbau.webp" alt="Au\xC3\x9Fenanlagen" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
+        <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
+          <span class="text-[var(--primary-color)] text-sm font-semibold">Zur Galerie</span>
+        </div>
+      </div>
+      <div class="p-6">
+        <h3 class="text-xl font-bold text-secondary-color mb-1">Au\xC3\x9Fenanlagen</h3>
+        <p class="text-sm text-gray-600 mb-5">Gestaltung von Au\xC3\x9Fenbereichen und Freifl\xC3\xA4chen.</p>
+        <span class="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary-color)] hover:underline">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+          Zur Galerie
+        </span>
+      </div>
+    </a>
+
+    <!-- Dachdeckung & Dachabdichtung -->
+    <a href="Referenzen/dachdeckung-und-dachabdichtung.html" class="group block bg-white border border-gray-100 rounded-3xl overflow-hidden shadow-md hover:shadow-xl transition duration-300">
+      <div class="relative overflow-hidden">
+        <img src="images/pexels-sevenstormphotography-439416.jpg" alt="Dachdeckung & Dachabdichtung" loading="lazy" class="w-full h-52 object-cover transform group-hover:scale-105 transition-transform duration-500">
+        <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
+          <span class="text-[var(--primary-color)] text-sm font-semibold">Zur Galerie</span>
+        </div>
+      </div>
+      <div class="p-6">
+        <h3 class="text-xl font-bold text-secondary-color mb-1">Dachdeckung & Dachabdichtung</h3>
+        <p class="text-sm text-gray-600 mb-5">Sichere Dachl\xC3\xB6sungen f\xC3\xBCr jedes Geb\xC3\xA4ude.</p>
+        <span class="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary-color)] hover:underline">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+          Zur Galerie
+        </span>
+      </div>
+    </a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- apply the Erdbau hero layout to all Referenzen subpages
- remove extra back link and harmonise navigation link text

## Testing
- `grep -n "bg-gradient-to-br" -n Website/Referenzen/*.html`

------
https://chatgpt.com/codex/tasks/task_e_687e3470ef84832c93cfcad86ca5b0c8