### PR TITLE
Fix carousel stall after restart

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -816,6 +816,7 @@ if (nextBtn) {
 
     function startAutoScroll() {
       if (carousel._autoScrollId === null) {
+        carousel._currentSpeed = carousel._defaultSpeed; // ensure speed resumes
         carousel._autoScrollId = requestAnimationFrame(autoScrollStep);
         carousel.dataset.autoScrollActive = 'true';
       }


### PR DESCRIPTION
## Summary
- prevent `#referenzen-carousel` from resuming with zero speed

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687e6061764c832c8f82bed64ae32536