### PR TITLE
Fix lightbox on subpage galleries

### DIFF
--- a/Website/js/gallery-loader.js
+++ b/Website/js/gallery-loader.js
@@ -60,5 +60,9 @@ document.addEventListener("DOMContentLoaded", () => {
       link.appendChild(img);
       gallery.appendChild(link);
     });
+
+    if (typeof initLightbox === 'function') {
+      initLightbox();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- ensure `GLightbox` is initialized after gallery images are dynamically inserted

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e64c4c720832c9d73fb9ef7474697