### PR TITLE
Limit AOS delay in gallery

### DIFF
--- a/Website/js/gallery-loader.js
+++ b/Website/js/gallery-loader.js
@@ -48,7 +48,8 @@ document.addEventListener("DOMContentLoaded", () => {
       link.className =
         "glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10";
       link.setAttribute("data-aos", "zoom-in");
-      link.setAttribute("data-aos-delay", `${(i + 1) * 50}`);
+      const delay = Math.min((i + 1) * 50, 1000);
+      link.setAttribute("data-aos-delay", `${delay}`);
       link.setAttribute("aria-label", `${folder} Bild ${num}`);
 
       const img = document.createElement("img");


### PR DESCRIPTION
## Summary
- cap `data-aos-delay` values in `gallery-loader.js` so animations don't queue too long

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e66625ba8832c9ca94f8b258d9403