### PR TITLE
Fix Kanalbau gallery image prefixes

### DIFF
--- a/Website/js/gallery-loader.js
+++ b/Website/js/gallery-loader.js
@@ -7,8 +7,8 @@ const galleryConfigs = {
     { prefix: "2.erdbau_", count: 39 }
   ],
   "kanalbau-referenzen": [
-    { prefix: "1.erdbau_", count: 17 },
-    { prefix: "2.erdbau_", count: 51 }
+    { prefix: "1.kanalbau_", count: 17 },
+    { prefix: "2.kanalbau_", count: 51 }
   ],
   "holzbau-referenzen": [
     { prefix: "1.holzbau_", count: 85 },


### PR DESCRIPTION
## Summary
- correct Kanalbau prefix names in `gallery-loader.js`

## Testing
- `node - <<'NODE'
const fs=require('fs');
const content=fs.readFileSync('Website/js/gallery-loader.js','utf8');
const match=content.match(/const galleryConfigs = ({[\s\S]*?});/);
const code=match[1];
const vm=require('vm');
const sandbox={};
vm.createContext(sandbox);
vm.runInContext('galleryConfigs='+code, sandbox);
function buildFileList(groups){const files=[];groups.forEach(({prefix,count})=>{for(let i=1;i<=count;i++)files.push(`${prefix}${i}.jpg`);});return files;}
const files=buildFileList(sandbox.galleryConfigs['kanalbau-referenzen']);
console.log(files.length, files[0], files[files.length-1]);
NODE

------
https://chatgpt.com/codex/tasks/task_e_687e665943ac832cbf8e170c7d08978d