### PR TITLE
Add infinite scroll to gallery loader

### DIFF
--- a/Website/js/gallery-loader.js
+++ b/Website/js/gallery-loader.js
@@ -23,6 +23,9 @@ const galleryConfigs = {
   ]
 };
 
+const INITIAL_COUNT = 20;
+const BATCH_SIZE = 20;
+
 function buildFileList(groups) {
   const files = [];
   groups.forEach(({ prefix, count }) => {
@@ -33,36 +36,89 @@ function buildFileList(groups) {
   return files;
 }
 
+function createImageLink(folder, file, index) {
+  const link = document.createElement("a");
+  link.href = `../images/${folder}/${file}`;
+  link.className =
+    "glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10";
+  link.setAttribute("data-aos", "zoom-in");
+  const delay = Math.min((index + 1) * 50, 1000);
+  link.setAttribute("data-aos-delay", `${delay}`);
+  link.setAttribute("aria-label", `${folder} Bild ${index + 1}`);
+
+  const img = document.createElement("img");
+  img.src = `../images/${folder}/${file}`;
+  img.alt = `${folder} ${index + 1}`;
+  img.loading = "lazy";
+  img.className = "w-full h-auto";
+
+  link.appendChild(img);
+  return link;
+}
+
+function appendBatch(gallery, folder, files, startIndex) {
+  files.forEach((file, i) => {
+    const link = createImageLink(folder, file, startIndex + i);
+    const sentinel = gallery.querySelector('.gallery-sentinel');
+    if (sentinel) {
+      gallery.insertBefore(link, sentinel);
+    } else {
+      gallery.appendChild(link);
+    }
+  });
+
+  if (typeof initLightbox === 'function') {
+    initLightbox();
+  }
+
+  if (window.AOS && typeof AOS.refresh === 'function') {
+    AOS.refresh();
+  }
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".gallery[data-folder]").forEach(gallery => {
     const folder = gallery.dataset.folder;
     const config = galleryConfigs[folder];
     if (!config) return;
+
     const files = buildFileList(config);
+    const remaining = files.slice(INITIAL_COUNT);
 
-    files.forEach((file, i) => {
-      const num = i + 1;
-      const link = document.createElement("a");
-      link.href = `../images/${folder}/${file}`;
-      link.className =
-        "glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10";
-      link.setAttribute("data-aos", "zoom-in");
-      const delay = Math.min((i + 1) * 50, 1000);
-      link.setAttribute("data-aos-delay", `${delay}`);
-      link.setAttribute("aria-label", `${folder} Bild ${num}`);
+    gallery._remainingFiles = remaining;
+    gallery._loadedCount = 0;
 
-      const img = document.createElement("img");
-      img.src = `../images/${folder}/${file}`;
-      img.alt = `${folder} ${num}`;
-      img.loading = "lazy";
-      img.className = "w-full h-auto";
+    appendBatch(gallery, folder, files.slice(0, INITIAL_COUNT), 0);
+    gallery._loadedCount += Math.min(INITIAL_COUNT, files.length);
 
-      link.appendChild(img);
-      gallery.appendChild(link);
-    });
+    if (remaining.length > 0) {
+      const sentinel = document.createElement('div');
+      sentinel.className = 'gallery-sentinel';
+      sentinel.style.height = '1px';
+      sentinel.style.width = '100%';
+      sentinel.style.visibility = 'hidden';
+      gallery.appendChild(sentinel);
 
-    if (typeof initLightbox === 'function') {
-      initLightbox();
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            observer.unobserve(entry.target);
+            const nextBatch = gallery._remainingFiles.splice(0, BATCH_SIZE);
+            if (nextBatch.length) {
+              appendBatch(gallery, folder, nextBatch, gallery._loadedCount);
+              gallery._loadedCount += nextBatch.length;
+            }
+            if (gallery._remainingFiles.length > 0) {
+              gallery.appendChild(sentinel);
+              observer.observe(sentinel);
+            } else {
+              sentinel.remove();
+            }
+          }
+        });
+      });
+
+      observer.observe(sentinel);
     }
   });
 });


### PR DESCRIPTION
## Summary
- add lazy loading constants and helpers for gallery loading
- append images in batches triggered by an IntersectionObserver
- refresh GLightbox each time new images are added

## Testing
- `node -c Website/js/gallery-loader.js`

------
https://chatgpt.com/codex/tasks/task_e_687f2ead6e6c832cab361e54269461ec