### PR TITLE
Fix overlay timeout

### DIFF
--- a/Website/css/style.css
+++ b/Website/css/style.css
@@ -134,7 +134,7 @@ body {
   transform: scale(1.03);
   visibility: hidden;
   pointer-events: none;
-  transition: opacity 0.7s ease-in, transform 0.7s ease-in;
+  transition: opacity 0.4s ease-in, transform 0.4s ease-in;
 }
 
 

--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -242,9 +242,11 @@ function setupPageTransitions() {
         const heroMedia = document.querySelector('[data-hero-media]');
 
         let overlayHidden = false;
+        let overlayTimeout;
         const hideOverlay = () => {
             if (overlayHidden) return;
             overlayHidden = true;
+            clearTimeout(overlayTimeout);
             overlay.classList.remove("is-fading-in");
             overlay.classList.add("is-fading-out");
 
@@ -260,6 +262,9 @@ function setupPageTransitions() {
                 overlay.removeEventListener("transitionend", handler);
             }, { once: true });
         };
+
+        overlayTimeout = setTimeout(hideOverlay, 3000);
+        hideOverlay();
 
         if (heroMedia) {
             if (heroMedia.tagName === 'VIDEO') {
@@ -281,7 +286,7 @@ function setupPageTransitions() {
                 else heroMedia.addEventListener('load', hideOverlay, { once: true });
             }
         } else {
-            window.addEventListener('load', hideOverlay, { once: true });
+            hideOverlay();
         }
     } else {
         Object.assign(overlay.style, {


### PR DESCRIPTION
## Summary
- ensure page transition overlay disappears on DOMContentLoaded
- shorten the fade‑out animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f3f652240832ca38d2d51d634c492