### PR TITLE
Fix Referenzen carousel intersection behavior

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -852,14 +852,17 @@ if (nextBtn) {
         cancelAnimationFrame(carousel._zoomRafId);
         carousel._zoomRafId = null;
       }
+
     }
 
+    let hasBeenVisible = false;
     const visibilityObserver = new IntersectionObserver((entries) => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
+          hasBeenVisible = true;
           startZoomLoop();
           startAutoScroll();
-        } else {
+        } else if (hasBeenVisible) {
           stopZoomLoop();
           stopAutoScroll();
         }


### PR DESCRIPTION
## Summary
- add visibility flag to references carousel
- stop auto-scroll/zoom only after carousel has been seen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f4b240ee8832cb1cacf2700c59302