### PR TITLE
Remove offscreen pause in carousel

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -855,21 +855,6 @@ if (nextBtn) {
 
     }
 
-    let hasBeenVisible = false;
-    const visibilityObserver = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          hasBeenVisible = true;
-          startZoomLoop();
-          startAutoScroll();
-        } else if (hasBeenVisible) {
-          stopZoomLoop();
-          stopAutoScroll();
-        }
-      });
-    }, { threshold: 0 });
-
-    visibilityObserver.observe(carousel);
 
     const observer = new IntersectionObserver((entries) => {
       entries.forEach(entry => {


### PR DESCRIPTION
## Summary
- remove the IntersectionObserver that paused the Referenzen carousel when it was out of view

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687f59e82e64832c9af4d8fccd028a52