### PR TITLE
Fix gallery thumbnails fallback

### DIFF
--- a/Website/js/gallery-loader.js
+++ b/Website/js/gallery-loader.js
@@ -60,6 +60,10 @@ function createImageLink(folder, file, index) {
 
   const img = document.createElement("img");
   img.src = `../images/${folder}/thumbs/${file}`;
+  img.onerror = () => {
+    img.onerror = null;
+    img.src = `../images/${folder}/${file}`;
+  };
   img.alt = `${folder} ${index + 1}`;
   img.loading = "lazy";
   img.className = "w-full h-auto";


### PR DESCRIPTION
## Summary
- ensure galleries load full-size images when thumbnails fail

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f5e2e6a00832cb9dbca1cc935b792