### PR TITLE
Update gallery animation to fade

### DIFF
--- a/Website/js/gallery-loader.js
+++ b/Website/js/gallery-loader.js
@@ -39,8 +39,8 @@ function createImageLink(folder, file, index) {
   link.href = `../images/${folder}/${file}`;
   link.className =
     "glightbox block overflow-hidden rounded-xl transition duration-500 ease-in-out transform hover:scale-105 hover:shadow-2xl hover:z-10";
-  link.setAttribute("data-aos", "zoom-in");
-  const delay = Math.min((index + 1) * 50, 1000);
+  link.setAttribute("data-aos", "fade-up");
+  const delay = Math.min((index + 1) * 30, 900);
   link.setAttribute("data-aos-delay", `${delay}`);
   link.setAttribute("aria-label", `${folder} Bild ${index + 1}`);
 


### PR DESCRIPTION
## Summary
- use `fade-up` animation in the gallery loader
- quicken AOS delay increments for a snappier load effect

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687f6171a670832cbad81fd71f6392ea