### PR TITLE
Shorten page overlay transitions

### DIFF
--- a/Website/css/style.css
+++ b/Website/css/style.css
@@ -82,7 +82,7 @@ body {
   visibility: hidden;
   pointer-events: none;
   will-change: opacity, transform;
-  transition: opacity 0.5s ease-in-out, transform 0.5s ease-in-out;
+  transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
 }
 
 
@@ -118,7 +118,7 @@ body {
   transform: scale(1);
   visibility: visible;
   pointer-events: all;
-  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+  transition: opacity 0.3s ease-out, transform 0.3s ease-out;
 }
 
 .is-transitioning .page-transition-overlay {
@@ -126,7 +126,7 @@ body {
   transform: scale(1);
   visibility: visible;
   pointer-events: all;
-  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+  transition: opacity 0.3s ease-out, transform 0.3s ease-out;
 }
 
 .page-transition-overlay.is-fading-out {
@@ -134,7 +134,7 @@ body {
   transform: scale(1.03);
   visibility: hidden;
   pointer-events: none;
-  transition: opacity 0.4s ease-in, transform 0.4s ease-in;
+  transition: opacity 0.3s ease-in, transform 0.3s ease-in;
 }
 
 


### PR DESCRIPTION
## Summary
- speed up page transition overlay timings for a lighter feel

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_687f61700acc832cae8ab72731f57968