### PR TITLE
Remove duplicate form validation init

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -170,14 +170,8 @@ function initFormValidation(formId) {
   });
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  initFormValidation("contactForm");
-});
-
-
-
-
-
+// Former standalone DOMContentLoaded listener removed. Form validation is
+// initialized within the main DOMContentLoaded bootstrap below.
 
 // ========== Highlight Active Navigation Links ============
 function markActiveLinks(containerSelector, currentPath) {


### PR DESCRIPTION
## Summary
- delete the redundant DOMContentLoaded block that only called `initFormValidation`
- leave `initFormValidation` inside the main bootstrap event

## Testing
- `grep -n "initFormValidation(" Website/js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_687f7f26b6bc832cb832c4be5aebc488