### PR TITLE
Improve gallery image alt texts

### DIFF
--- a/Website/README.md
+++ b/Website/README.md
@@ -43,5 +43,28 @@ und `scripts/generate-dimensions.js` ausgeführt werden, um Thumbnails und
 Abmessungsdaten aktuell zu halten. Für `scripts/make-thumbnails.sh` wird
 ImageMagick benötigt.
 
+## Alt-Texte für Galeriebilder
+Die Alt-Texte der Referenzgalerien werden standardmäßig aus dem Dateinamen
+abgeleitet. Numerische Präfixe wie `1.` und Unterstriche werden entfernt, so dass
+`1.abbruch_1.jpg` den Alt-Text `abbruch 1` erhält. Soll ein Bild einen anderen
+Alt-Text bekommen, kann im JSON `js/image-dimensions.json` ein optionales
+`"alt"`-Feld hinterlegt werden:
+
+```json
+{
+  "abbruch-referenzen": {
+    "1.abbruch_1.jpg": {
+      "width": 400,
+      "height": 711,
+      "alt": "Abriss eines alten Gebäudes"
+    }
+  }
+}
+```
+
+`gallery-loader.js` liest dieses Feld und verwendet es, falls vorhanden. Wird
+`scripts/generate-dimensions.js` erneut ausgeführt, müssen benutzerdefinierte
+Alt-Texte anschließend wieder eingetragen werden.
+
 ## Lizenz
 Veröffentlicht unter der [MIT-Lizenz](LICENSE).

--- a/Website/js/gallery-loader.js
+++ b/Website/js/gallery-loader.js
@@ -17,6 +17,13 @@ function deriveCounts(total) {
 
 let imageDimensions = {};
 
+function getAltText(folder, file) {
+  const alt = imageDimensions?.[folder]?.[file]?.alt;
+  if (alt) return alt;
+  const base = file.replace(/\.[^.]+$/, '').replace(/^\d+\./, '');
+  return base.replace(/_/g, ' ');
+}
+
 function naturalSort(a, b) {
   return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
 }
@@ -53,7 +60,7 @@ function createImageLink(folder, file, index) {
     img.onerror = null;
     img.src = `../images/${folder}/${file}`;
   };
-  img.alt = `${folder} ${index + 1}`;
+  img.alt = getAltText(folder, file);
   img.loading = "lazy";
   img.className = "w-full h-auto";
   const dims = imageDimensions?.[folder]?.[file];


### PR DESCRIPTION
## Summary
- generate alt text from filenames in `gallery-loader.js`
- allow custom alt text via `image-dimensions.json`
- document how to set custom alt texts

## Testing
- `node -e "const x=require('./Website/js/image-dimensions.json'); console.log(Object.keys(x).length);"`

------
https://chatgpt.com/codex/tasks/task_e_687f8be710ec832c9ecfd44417983160