### PR TITLE
Update page transition state handling

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -206,27 +206,28 @@ function setupPageTransitions() {
     }
 
     window.addEventListener('pageshow', (e) => {
-        if (sessionStorage.getItem('isTransitioning') !== 'true' || e.persisted) {
-            overlay.classList.remove('is-fading-in', 'is-fading-out');
-            Object.assign(overlay.style, {
-                opacity: '0',
-                visibility: 'hidden',
-                pointerEvents: 'none'
-            });
-            document.documentElement.classList.remove('is-transitioning');
+        if (e.persisted || sessionStorage.getItem('isTransitioning') === 'true') {
+            sessionStorage.removeItem('isTransitioning');
         }
+
+        overlay.classList.remove('is-fading-in', 'is-fading-out');
+        Object.assign(overlay.style, {
+            opacity: '0',
+            visibility: 'hidden',
+            pointerEvents: 'none'
+        });
+        document.documentElement.classList.remove('is-transitioning');
     });
 
-    window.addEventListener('pagehide', (e) => {
-        if (sessionStorage.getItem('isTransitioning') !== 'true' || e.persisted) {
-            overlay.classList.remove('is-fading-in', 'is-fading-out');
-            Object.assign(overlay.style, {
-                opacity: '0',
-                visibility: 'hidden',
-                pointerEvents: 'none'
-            });
-            document.documentElement.classList.remove('is-transitioning');
-        }
+    window.addEventListener('pagehide', () => {
+        sessionStorage.removeItem('isTransitioning');
+        overlay.classList.remove('is-fading-in', 'is-fading-out');
+        Object.assign(overlay.style, {
+            opacity: '0',
+            visibility: 'hidden',
+            pointerEvents: 'none'
+        });
+        document.documentElement.classList.remove('is-transitioning');
     });
 
     if (sessionStorage.getItem("isTransitioning") === "true") {


### PR DESCRIPTION
## Summary
- handle persisted pages and transitions by clearing session storage before hiding overlay
- remove transition state on pagehide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fa0c02e48832c82c179eb57ce9fc7