### PR TITLE
Detect back/forward navigation to preserve scroll

### DIFF
--- a/Website/js/app.js
+++ b/Website/js/app.js
@@ -335,10 +335,15 @@ function loadHeroVideo() {
 
 // ========== DOMContentLoaded Bootstrap ============
 document.addEventListener("DOMContentLoaded", () => {
+  const navEntry = performance.getEntriesByType('navigation')[0];
+  const isBackForward = navEntry && navEntry.type === 'back_forward';
+
   if ("scrollRestoration" in window.history) {
-    window.history.scrollRestoration = "manual";
+    window.history.scrollRestoration = isBackForward ? "auto" : "manual";
   }
-  window.scrollTo(0, 0);
+  if (!isBackForward) {
+    window.scrollTo(0, 0);
+  }
 
   if (window.AOS) {
     AOS.init({ once: true, duration: 400, easing: 'ease-out' });


### PR DESCRIPTION
## Summary
- detect history navigation in DOMContentLoaded
- skip forced scroll to top when returning via browser history

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fa0c1825c832c95f722e6aa828741